### PR TITLE
test: native unit-test suite for decision logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
     name: Unit tests (native)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Cache PlatformIO
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.platformio/.cache
@@ -35,12 +35,12 @@ jobs:
     name: Firmware build (bluepill_f103c8)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Cache PlatformIO
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.platformio/.cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Unit tests (native)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio/.cache
+            ~/.cache/pip
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
+          restore-keys: ${{ runner.os }}-pio-
+      - name: Install PlatformIO
+        run: pip install --upgrade platformio
+      - name: Run native unit tests
+        run: pio test -e native
+
+  build:
+    name: Firmware build (bluepill_f103c8)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio/.cache
+            ~/.cache/pip
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
+          restore-keys: ${{ runner.os }}-pio-
+      - name: Install PlatformIO
+        run: pip install --upgrade platformio
+      - name: Build firmware
+        run: pio run -e bluepill_f103c8

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,27 +18,35 @@ opens/closes **twin flap servos** (in tandem) on a temperature threshold, and sh
 pio run -e bluepill_f103c8            # build
 pio run -e bluepill_f103c8 -t upload  # flash via ST-Link (upload_protocol = stlink)
 pio device monitor -b 115200          # serial monitor
+pio test -e native                    # run host unit tests (no hardware)
 pio run -t clean                      # clean
 ```
 
-No unit tests (`test/` is a PlatformIO placeholder). Libs (`platformio.ini`): Adafruit SSD1306 + GFX.
+Libs (`platformio.ini`): Adafruit SSD1306 + GFX (firmware); Unity (native tests, auto-installed).
 
 ## Architecture
 
-All logic is in `src/main.cpp`:
+Decision logic lives in `lib/decision/` (pure, Arduino-free, unit-tested); `src/main.cpp` owns
+hardware I/O and state and calls into it:
 
+- **`lib/decision/decision.{h,cpp}`** — `evaluateSituation()` (priority matrix §3), `nextFlapState()`
+  (§5 hysteresis), `nextLowPressAlarm()` (§4), `temperatureBand()`, `situationAlert()`,
+  `interpolate()` and the sensor scale tables. All pure functions taking state as parameters.
 - `setup()` — serial @115200, status LED, OLED init (blocks in `blinkErrorLED()` on failure),
   servo attach + close, 12-bit ADC.
-- `loop()` @200 ms — temp resistance → °C, pressure voltage → bar, then the **situation matrix**:
-  `evaluateSituation()` picks the highest-priority active situation (`DECISION_MATRIX.md` §3),
-  dispatched to `applyFlap()` (servos + hysteresis §5), `applyAlertLed()` (onboard backup LED),
-  `onSituationChange()` (edge-triggered sound/voice — stubbed), and `updateDisplay()`.
-- Shared helpers `readPinVoltage()` and `interpolate()` (piecewise-linear) serve both sensors.
-  `updateLowPressAlarm()` holds the adaptive low-pressure floor with hysteresis (§4).
+- `loop()` @200 ms — read sensors, then run the decision functions and dispatch outputs:
+  `applyFlap()` (twin servos), `applyAlertLed()` (onboard backup LED), `onSituationChange()`
+  (edge-triggered sound/voice — stubbed), and `updateDisplay()`. `main.cpp` holds the evolving
+  state (`flapOpen`, `lowPressAlarm`, `prevSituation`).
+- **Tests**: `test/test_decision/` (Unity) run via `pio test -e native` against `lib/decision` —
+  the `native` env excludes `src/` so no hardware/toolchain is needed.
 
 **Conventions to preserve:**
-- Interpolation x-tables (`resTable`, `vPressureTable`) **must stay strictly increasing**, each in
-  sync with its y-table (`tempTable`, `barTable`) — `interpolate()` assumes it.
+- `lib/decision` stays Arduino-free (pure functions, state passed in) so it builds natively — keep
+  hardware (Servo/OLED/ADC/tone) in `src/main.cpp`. Add a test when you add decision logic.
+- Interpolation x-tables (`resTable`, `vPressureTable` in `lib/decision/decision.cpp`) **must stay
+  strictly increasing**, each in sync with its y-table (`tempTable`, `barTable`) — `interpolate()`
+  assumes it.
 - Keep the sensor fail-safes: resistance ≥ `TEMP_MAX_SAFE_RESISTANCE` → `TEMPERATURE ERROR`;
   pressure volt < `PRESS_MIN_SAFE_VOLTAGE` → `PRESSURE ERROR`.
 

--- a/lib/decision/decision.cpp
+++ b/lib/decision/decision.cpp
@@ -1,0 +1,106 @@
+#include "decision.h"
+
+// ----- Sensor scale tables (x must stay strictly increasing) -----
+static const float resTable[]  = {32.0, 41.0, 68.0, 120.0, 224.0, 438.0, 925.0};
+static const float tempTable[] = {150.0, 140.0, 120.0, 100.0, 80.0, 60.0, 40.0};
+static const uint8_t tempTableSize = sizeof(tempTable) / sizeof(tempTable[0]);
+
+static const float vPressureTable[] = {0.5, 0.87, 1.25, 1.77, 2.22, 2.55, 2.79, 2.91, 3.01};
+static const float barTable[]       = {0.0, 1.0,  2.0,  3.5,  5.0,  6.5,  8.0,  9.0,  10.0};
+static const uint8_t pressTableSize = sizeof(vPressureTable) / sizeof(vPressureTable[0]);
+
+// ----- Adaptive low-pressure floor (§4), indexed by temperature band 0..4 -----
+static const float pressCritical[] = {1.5f, 0.9f, 0.8f, 0.6f, 1.2f}; // alarm below
+static const float pressRearm[]    = {1.8f, 1.1f, 1.0f, 0.8f, 1.2f}; // clear at/above
+
+float interpolate(float x, const float* xTable, const float* yTable, uint8_t size) {
+    if (x <= xTable[0]) return yTable[0];
+    if (x >= xTable[size - 1]) return yTable[size - 1];
+
+    for (uint8_t i = 0; i < size - 1; i++) {
+        if (x >= xTable[i] && x <= xTable[i + 1]) {
+            return yTable[i] + (x - xTable[i]) * (yTable[i + 1] - yTable[i]) / (xTable[i + 1] - xTable[i]);
+        }
+    }
+    return yTable[size - 1]; // fallback
+}
+
+float temperatureFromResistance(float resistance) {
+    if (resistance >= TEMP_MAX_SAFE_RESISTANCE) return tempTable[0]; // max temp for safety
+    return interpolate(resistance, resTable, tempTable, tempTableSize);
+}
+
+float pressureFromVoltage(float vPressure) {
+    return interpolate(vPressure, vPressureTable, barTable, pressTableSize);
+}
+
+uint8_t temperatureBand(float temperature) {
+    if (temperature < TEMP_NORMAL)       return 0; // < 70
+    if (temperature < TEMP_REGULATION)   return 1; // 70-89
+    if (temperature < TEMP_OVERHEAT)     return 2; // 90-110
+    if (temperature <= TEMP_STOP_ENGINE) return 3; // 110-122
+    return 4;                                      // > 122
+}
+
+bool nextLowPressAlarm(bool prev, float temperature, float pressure) {
+    uint8_t b = temperatureBand(temperature);
+    if (!prev && pressure < pressCritical[b])  return true;
+    if (prev && pressure >= pressRearm[b])      return false;
+    return prev;
+}
+
+Situation evaluateSituation(float resistance, float vPressure, float temperature,
+                            float pressure, bool lowPressAlarm) {
+    if (resistance >= TEMP_MAX_SAFE_RESISTANCE)                          return SIT_TEMP_SENSOR_ERR;
+    if (vPressure < PRESS_MIN_SAFE_VOLTAGE)                              return SIT_PRESS_SENSOR_ERR;
+    if (temperature > TEMP_STOP_ENGINE && pressure < PRESS_STOP_ENGINE) return SIT_STOP_ENGINE;
+    if (lowPressAlarm)                                                  return SIT_LOW_PRESSURE;
+    if (pressure > PRESS_OVER)                                          return SIT_OVERPRESSURE;
+    if (temperature >= TEMP_OVERHEAT)                                   return SIT_MILD_OVERHEAT;
+    if (temperature >= TEMP_REGULATION)                                 return SIT_REGULATION;
+    if (temperature >= TEMP_NORMAL)                                     return SIT_NORMAL;
+    return SIT_COLD;
+}
+
+bool nextFlapState(Situation sit, float temperature, bool prevFlapOpen) {
+    switch (sit) {
+        case SIT_TEMP_SENSOR_ERR:
+        case SIT_PRESS_SENSOR_ERR:
+        case SIT_STOP_ENGINE:
+        case SIT_LOW_PRESSURE:
+        case SIT_MILD_OVERHEAT:
+            return true;            // force open (favour cooling)
+        case SIT_OVERPRESSURE:
+            return prevFlapOpen;    // unchanged
+        default:                    // REGULATION / NORMAL / COLD -> hysteresis
+            if (!prevFlapOpen && temperature >= FLAP_OPEN_TEMP) return true;
+            if (prevFlapOpen && temperature <= FLAP_CLOSE_TEMP) return false;
+            return prevFlapOpen;
+    }
+}
+
+AlertLevel situationAlert(Situation sit) {
+    switch (sit) {
+        case SIT_TEMP_SENSOR_ERR:
+        case SIT_PRESS_SENSOR_ERR:
+        case SIT_STOP_ENGINE:
+        case SIT_LOW_PRESSURE:
+        case SIT_OVERPRESSURE:   return ALERT_ALARM;
+        case SIT_MILD_OVERHEAT:  return ALERT_WARN;
+        default:                 return ALERT_OFF;
+    }
+}
+
+const char* situationName(Situation sit) {
+    switch (sit) {
+        case SIT_TEMP_SENSOR_ERR:  return "TEMP SENS ERR";
+        case SIT_PRESS_SENSOR_ERR: return "PRESS SENS ERR";
+        case SIT_STOP_ENGINE:      return "STOP ENGINE";
+        case SIT_LOW_PRESSURE:     return "LOW PRESSURE";
+        case SIT_OVERPRESSURE:     return "OVERPRESSURE";
+        case SIT_MILD_OVERHEAT:    return "MILD OVERHEAT";
+        case SIT_REGULATION:       return "REGULATION";
+        case SIT_NORMAL:           return "NORMAL";
+        default:                   return "COLD";
+    }
+}

--- a/lib/decision/decision.h
+++ b/lib/decision/decision.h
@@ -1,0 +1,60 @@
+#pragma once
+#include <stdint.h>
+
+// Hardware-independent decision logic for the SWEE.BRZ oil monitor.
+// Pure functions only (no Arduino) so they can be unit-tested natively.
+// See DECISION_MATRIX.md (§3 situations, §4 pressure floor, §5 hysteresis).
+
+// Situations by priority (top = highest); first true wins (§3).
+enum Situation {
+    SIT_TEMP_SENSOR_ERR,  // 1  R > TEMP_MAX_SAFE_RESISTANCE
+    SIT_PRESS_SENSOR_ERR, // 2  V < PRESS_MIN_SAFE_VOLTAGE
+    SIT_STOP_ENGINE,      // 3  too hot AND too low pressure
+    SIT_LOW_PRESSURE,     // 4  pressure below adaptive floor (§4)
+    SIT_OVERPRESSURE,     // 5  pressure above ceiling
+    SIT_MILD_OVERHEAT,    // 6  hot but pressure OK
+    SIT_REGULATION,       // 7  warm, flap regulating
+    SIT_NORMAL,           // 8  normal operating band
+    SIT_COLD,             // 9  engine cold
+};
+
+// Alert level mapped to the indicator channel (LED colour).
+enum AlertLevel { ALERT_OFF, ALERT_WARN, ALERT_ALARM }; // off / yellow / red
+
+// ----- Thresholds -----
+constexpr float TEMP_MAX_SAFE_RESISTANCE = 1500.0f; // above -> temp sensor fault
+constexpr float PRESS_MIN_SAFE_VOLTAGE   = 0.3f;    // below -> pressure sensor fault
+constexpr float FLAP_OPEN_TEMP  = 92.0f;            // flap hysteresis open (§5)
+constexpr float FLAP_CLOSE_TEMP = 85.0f;            // flap hysteresis close (§5)
+constexpr float TEMP_STOP_ENGINE = 122.0f;          // with low pressure -> stop engine
+constexpr float TEMP_OVERHEAT    = 110.0f;          // mild overheat band start
+constexpr float TEMP_REGULATION  = 90.0f;           // thermal-regulation band start
+constexpr float TEMP_NORMAL      = 70.0f;           // normal band start
+constexpr float PRESS_STOP_ENGINE = 1.2f;           // stop-engine pressure
+constexpr float PRESS_OVER        = 6.5f;           // overpressure ceiling
+
+// ----- Pure helpers -----
+
+// Piecewise-linear lookup; xTable must be strictly increasing, same size as yTable.
+float interpolate(float x, const float* xTable, const float* yTable, uint8_t size);
+
+// Sensor conversions (use the built-in scale tables).
+float temperatureFromResistance(float resistance); // clamps to max-temp on fault
+float pressureFromVoltage(float vPressure);
+
+// Temperature band index: 0:<70  1:70-89  2:90-110  3:110-122  4:>122
+uint8_t temperatureBand(float temperature);
+
+// Adaptive low-pressure alarm with per-band hysteresis (§4); returns next state.
+bool nextLowPressAlarm(bool prev, float temperature, float pressure);
+
+// Priority-ordered situation evaluation (§3). lowPressAlarm is the §4 state.
+Situation evaluateSituation(float resistance, float vPressure, float temperature,
+                            float pressure, bool lowPressAlarm);
+
+// Next flap state: safety situations force open, overpressure holds, normal bands
+// use temperature hysteresis (§5); returns true = open.
+bool nextFlapState(Situation sit, float temperature, bool prevFlapOpen);
+
+AlertLevel situationAlert(Situation sit);
+const char* situationName(Situation sit);

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,13 @@ upload_protocol = stlink
 
 monitor_speed = 115200
 
-lib_deps = 
+lib_deps =
     adafruit/Adafruit SSD1306 @ ^2.5.7
     adafruit/Adafruit GFX Library @ ^1.11.5
+
+; Host-native env for unit-testing the pure decision logic (lib/decision).
+; Excludes src/ (Arduino) so only the library + tests build. Run: pio test -e native
+[env:native]
+platform = native
+test_framework = unity
+build_src_filter = -<*>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,11 +3,10 @@
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
-#include "pins.h"   // pin map (single source of truth)
+#include "pins.h"      // pin map (single source of truth)
+#include "decision.h"  // hardware-independent decision logic (unit-tested)
 
 // ========== CONFIGURATION ==========
-
-// /!\ Order of interpolation tables should be in INCREASING order
 
 // ----- OLED Screen -----
 #define SCREEN_WIDTH 128
@@ -21,66 +20,19 @@ Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &OLED_I2C, OLED_RESET);
 // ----- HARDWARE Constants -----
 const float VREF = 3.3f;
 const uint16_t ADC_MAX = 4095;
-
-// ----- TEMPERATURE Sensor -----
-const float TEMP_SERIES_RESISTOR = 220.0f;
-// Threshold
-const float TEMP_MAX_SAFE_RESISTANCE = 1500.0f; // If the sensor reads above this resistance, it is likely disconnected/failed/oil temp is very low.
-// Flap hysteresis (DECISION_MATRIX §5): open at/above OPEN, close at/below CLOSE
-const float FLAP_OPEN_TEMP  = 92.0f;
-const float FLAP_CLOSE_TEMP = 85.0f;
-// Sensor scale
-const float resTable[]      =  {32.0,  41.0,  68.0,  120.0, 224.0, 438.0, 925.0}; // increasing mandatory here
-const float tempTable[]     =  {150.0, 140.0, 120.0, 100.0, 80.0,  60.0,  40.0};
-const uint8_t tempTableSize = sizeof(tempTable) / sizeof(tempTable[0]);
-
-// ----- PRESSURE Sensor -----
-const float PRESS_DIVIDER_RATIO = 1.5f; // 10/20 kOhm voltage divider
-const float PRESS_MIN_SAFE_VOLTAGE = 0.3f; // under this value we can consider disconnected
-// Sensor scale
-const float vPressureTable[] = {0.5, 0.87, 1.25, 1.77, 2.22, 2.55, 2.79, 2.91, 3.01}; // increasing mandatory here
-const float barTable[]       = {0.0, 1.0,  2.0,  3.5,  5.0,  6.5,  8.0,  9.0,  10.0};
-const uint8_t pressTableSize = sizeof(vPressureTable) / sizeof(vPressureTable[0]);
+const float TEMP_SERIES_RESISTOR = 220.0f; // temperature divider series resistor
+const float PRESS_DIVIDER_RATIO = 1.5f;    // 10/20 kOhm pressure divider
 
 // ----- FLAP Servos (twin, driven in tandem) -----
-const uint8_t FLAP_CLOSED = 0;
-const uint8_t FLAP_OPEN   = 90;
+const uint8_t FLAP_CLOSED = 0;  // servo angle
+const uint8_t FLAP_OPEN   = 90; // servo angle
 Servo flapServo1;
 Servo flapServo2;
-bool flapOpen = false; // current flap state (hysteresis), starts closed
 
-// ----- DECISION MATRIX (DECISION_MATRIX §3) -----
-// Situations evaluated by priority (top = highest); first true wins.
-enum Situation {
-    SIT_TEMP_SENSOR_ERR,  // 1  R > TEMP_MAX_SAFE_RESISTANCE
-    SIT_PRESS_SENSOR_ERR, // 2  V < PRESS_MIN_SAFE_VOLTAGE
-    SIT_STOP_ENGINE,      // 3  too hot AND too low pressure
-    SIT_LOW_PRESSURE,     // 4  pressure below adaptive floor (§4)
-    SIT_OVERPRESSURE,     // 5  pressure above ceiling
-    SIT_MILD_OVERHEAT,    // 6  hot but pressure OK
-    SIT_REGULATION,       // 7  warm, flap regulating
-    SIT_NORMAL,           // 8  normal operating band
-    SIT_COLD,             // 9  engine cold
-};
-
-// Alert level mapped to the indicator channel (LED colour).
-enum AlertLevel { ALERT_OFF, ALERT_WARN, ALERT_ALARM }; // off / yellow / red
-
-// Temperature band thresholds (°C)
-const float TEMP_STOP_ENGINE = 122.0f; // combined with low pressure -> stop engine
-const float TEMP_OVERHEAT    = 110.0f; // mild overheat band start
-const float TEMP_REGULATION  = 90.0f;  // thermal-regulation band start
-const float TEMP_NORMAL      = 70.0f;  // normal band start
-// Pressure thresholds (bar)
-const float PRESS_STOP_ENGINE = 1.2f;  // stop-engine pressure (with TEMP_STOP_ENGINE)
-const float PRESS_OVER        = 6.5f;  // overpressure ceiling
-
-// Adaptive low-pressure floor (§4), indexed by temperature band:
-// 0:<70  1:70-89  2:90-110  3:110-122  4:>122
-const float pressCritical[] = {1.5f, 0.9f, 0.8f, 0.6f, 1.2f}; // alarm below
-const float pressRearm[]    = {1.8f, 1.1f, 1.0f, 0.8f, 1.2f}; // clear at/above
-bool lowPressAlarm = false; // adaptive low-pressure alarm state (§4 hysteresis)
-int prevSituation = -1;     // last dispatched situation (for edge-triggered sound/voice)
+// ----- Decision state (held here, evolved by the pure decision functions) -----
+bool flapOpen = false;      // current flap state (hysteresis), starts closed
+bool lowPressAlarm = false; // adaptive low-pressure alarm state (§4)
+int prevSituation = -1;     // last dispatched situation (edge-triggered sound/voice)
 
 
 // ========== SETUP ==========
@@ -96,7 +48,7 @@ void setup() {
     Serial.begin(115200);
 
     delay(500); // important to let the screen initialize
-    
+
     // ----- Built in initialization -----
     pinMode(PIN_STATUS_LED, OUTPUT);
     digitalWrite(PIN_STATUS_LED, HIGH); // High is off for the built-in LED
@@ -113,33 +65,17 @@ void setup() {
     flapServo2.attach(PIN_SERVO_FLAP_2);
     flapServo1.write(FLAP_CLOSED);
     flapServo2.write(FLAP_CLOSED);
-    
+
     // ----- OTHER Settings -----
     analogReadResolution(12);
 }
 
 
-// ========== MATH and HARDWARE HELPERS ==========
+// ========== HARDWARE SENSOR READS ==========
 
 float readPinVoltage(uint8_t pin) {
     return analogRead(pin) * (VREF / ADC_MAX);
 }
-
-float interpolate(float x, const float* xTable, const float* yTable, uint8_t size) {
-    if (x <= xTable[0]) return yTable[0];
-    if (x >= xTable[size - 1]) return yTable[size - 1];
-
-    for (uint8_t i = 0; i < size - 1; i++) {
-        if (x >= xTable[i] && x <= xTable[i + 1]) {
-            return yTable[i] + (x - xTable[i]) * (yTable[i + 1] - yTable[i]) / (xTable[i + 1] - xTable[i]);
-        }
-    }
-    return yTable[size - 1]; // fallback
-}
-
-// ========== SENSOR Specific ==========
-
-// ----- TEMPERATURE -----
 
 float readTemperatureResistance() {
     float voltage = readPinVoltage(PIN_TEMP_SENSE);
@@ -147,97 +83,16 @@ float readTemperatureResistance() {
     return (voltage * TEMP_SERIES_RESISTOR) / (VREF - voltage);
 }
 
-float resistanceToTemperature(float resistance) {
-    if (resistance >= TEMP_MAX_SAFE_RESISTANCE) {
-        return tempTable[0]; // fallback to highest temp for safety
-    }
-    return interpolate(resistance, resTable, tempTable, tempTableSize);
-}
-
-// ----- PRESSURE -----
-
 float readPressureVoltage() {
     return readPinVoltage(PIN_PRESS_SENSE) * PRESS_DIVIDER_RATIO;
 }
 
-// ========== DECISION MATRIX ==========
-
-uint8_t temperatureBand(float t) {
-    if (t < TEMP_NORMAL)       return 0; // < 70
-    if (t < TEMP_REGULATION)   return 1; // 70-89
-    if (t < TEMP_OVERHEAT)     return 2; // 90-110
-    if (t <= TEMP_STOP_ENGINE) return 3; // 110-122
-    return 4;                            // > 122
-}
-
-// Adaptive low-pressure alarm with per-band hysteresis (§4).
-void updateLowPressAlarm(float temperature, float pressure) {
-    uint8_t b = temperatureBand(temperature);
-    if (!lowPressAlarm && pressure < pressCritical[b])      lowPressAlarm = true;
-    else if (lowPressAlarm && pressure >= pressRearm[b])    lowPressAlarm = false;
-}
-
-// Priority-ordered evaluation: first true wins (§3).
-Situation evaluateSituation(float resistance, float vPressure, float temperature, float pressure) {
-    if (resistance >= TEMP_MAX_SAFE_RESISTANCE)                          return SIT_TEMP_SENSOR_ERR;
-    if (vPressure < PRESS_MIN_SAFE_VOLTAGE)                              return SIT_PRESS_SENSOR_ERR;
-    if (temperature > TEMP_STOP_ENGINE && pressure < PRESS_STOP_ENGINE) return SIT_STOP_ENGINE;
-    if (lowPressAlarm)                                                  return SIT_LOW_PRESSURE;
-    if (pressure > PRESS_OVER)                                          return SIT_OVERPRESSURE;
-    if (temperature >= TEMP_OVERHEAT)                                   return SIT_MILD_OVERHEAT;
-    if (temperature >= TEMP_REGULATION)                                 return SIT_REGULATION;
-    if (temperature >= TEMP_NORMAL)                                     return SIT_NORMAL;
-    return SIT_COLD;
-}
-
-AlertLevel situationAlert(Situation sit) {
-    switch (sit) {
-        case SIT_TEMP_SENSOR_ERR:
-        case SIT_PRESS_SENSOR_ERR:
-        case SIT_STOP_ENGINE:
-        case SIT_LOW_PRESSURE:
-        case SIT_OVERPRESSURE:   return ALERT_ALARM;
-        case SIT_MILD_OVERHEAT:  return ALERT_WARN;
-        default:                 return ALERT_OFF;
-    }
-}
-
-const char* situationName(Situation sit) {
-    switch (sit) {
-        case SIT_TEMP_SENSOR_ERR:  return "TEMP SENS ERR";
-        case SIT_PRESS_SENSOR_ERR: return "PRESS SENS ERR";
-        case SIT_STOP_ENGINE:      return "STOP ENGINE";
-        case SIT_LOW_PRESSURE:     return "LOW PRESSURE";
-        case SIT_OVERPRESSURE:     return "OVERPRESSURE";
-        case SIT_MILD_OVERHEAT:    return "MILD OVERHEAT";
-        case SIT_REGULATION:       return "REGULATION";
-        case SIT_NORMAL:           return "NORMAL";
-        default:                   return "COLD";
-    }
-}
 
 // ========== SITUATION OUTPUTS ==========
 
 // ----- FLAP (servos) -----
-// Safety situations force the flap open; overpressure leaves it unchanged
-// (opening does not relieve pressure); normal bands use temperature hysteresis (§5).
-void applyFlap(Situation sit, float temperature) {
-    switch (sit) {
-        case SIT_TEMP_SENSOR_ERR:
-        case SIT_PRESS_SENSOR_ERR:
-        case SIT_STOP_ENGINE:
-        case SIT_LOW_PRESSURE:
-        case SIT_MILD_OVERHEAT:
-            flapOpen = true; // force open (favour cooling)
-            break;
-        case SIT_OVERPRESSURE:
-            break;           // unchanged
-        default:             // REGULATION / NORMAL / COLD
-            if (!flapOpen && temperature >= FLAP_OPEN_TEMP)      flapOpen = true;
-            else if (flapOpen && temperature <= FLAP_CLOSE_TEMP) flapOpen = false;
-            break;
-    }
-    uint8_t angle = flapOpen ? FLAP_OPEN : FLAP_CLOSED;
+void applyFlap(bool open) {
+    uint8_t angle = open ? FLAP_OPEN : FLAP_CLOSED;
     flapServo1.write(angle);
     flapServo2.write(angle);
 }
@@ -319,22 +174,21 @@ void updateDisplay(Situation sit, float temperature, float resistance, float pre
 // ========== MAIN LOOP ==========
 
 void loop() {
-    // ----- TEMPERATURE Computation -----
+    // ----- SENSOR Reads + conversions -----
     float resistance = readTemperatureResistance();
-    float temperature = resistanceToTemperature(resistance);
-
-    // ----- PRESSURE Computation -----
+    float temperature = temperatureFromResistance(resistance);
     float vPressure = readPressureVoltage();
-    float pressure = interpolate(vPressure, vPressureTable, barTable, pressTableSize);
+    float pressure = pressureFromVoltage(vPressure);
 
-    // ----- DECISION (§3) -----
+    // ----- DECISION (§3/§4) -----
     bool sensorsOk = (resistance < TEMP_MAX_SAFE_RESISTANCE) && (vPressure >= PRESS_MIN_SAFE_VOLTAGE);
-    if (sensorsOk) updateLowPressAlarm(temperature, pressure);
-    else           lowPressAlarm = false; // readings unreliable -> drop the adaptive alarm
-    Situation sit = evaluateSituation(resistance, vPressure, temperature, pressure);
+    lowPressAlarm = sensorsOk ? nextLowPressAlarm(lowPressAlarm, temperature, pressure)
+                              : false; // readings unreliable -> drop the adaptive alarm
+    Situation sit = evaluateSituation(resistance, vPressure, temperature, pressure, lowPressAlarm);
 
     // ----- OUTPUTS -----
-    applyFlap(sit, temperature);
+    flapOpen = nextFlapState(sit, temperature, flapOpen);
+    applyFlap(flapOpen);
     applyAlertLed(situationAlert(sit));
     if ((int)sit != prevSituation) { onSituationChange(sit); prevSituation = sit; }
     updateDisplay(sit, temperature, resistance, pressure, vPressure);

--- a/test/test_decision/test_decision.cpp
+++ b/test/test_decision/test_decision.cpp
@@ -1,0 +1,226 @@
+#include <unity.h>
+#include "decision.h"
+
+// Native unit tests for the pure decision logic (lib/decision).
+// Run: pio test -e native
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ---------- interpolate ----------
+
+void test_interpolate_below_range_clamps_low(void) {
+    const float x[] = {0, 1, 2};
+    const float y[] = {10, 20, 30};
+    TEST_ASSERT_EQUAL_FLOAT(10, interpolate(-5, x, y, 3));
+}
+
+void test_interpolate_above_range_clamps_high(void) {
+    const float x[] = {0, 1, 2};
+    const float y[] = {10, 20, 30};
+    TEST_ASSERT_EQUAL_FLOAT(30, interpolate(99, x, y, 3));
+}
+
+void test_interpolate_exact_knot(void) {
+    const float x[] = {0, 1, 2};
+    const float y[] = {10, 20, 30};
+    TEST_ASSERT_EQUAL_FLOAT(20, interpolate(1, x, y, 3));
+}
+
+void test_interpolate_midpoint(void) {
+    const float x[] = {0, 2};
+    const float y[] = {0, 100};
+    TEST_ASSERT_EQUAL_FLOAT(50, interpolate(1, x, y, 2));
+}
+
+// ---------- sensor conversions ----------
+
+void test_temperatureFromResistance_fault_clamps_to_max(void) {
+    // resistance >= TEMP_MAX_SAFE_RESISTANCE -> highest temp (safety)
+    TEST_ASSERT_EQUAL_FLOAT(150.0f, temperatureFromResistance(TEMP_MAX_SAFE_RESISTANCE));
+    TEST_ASSERT_EQUAL_FLOAT(150.0f, temperatureFromResistance(5000.0f));
+}
+
+void test_temperatureFromResistance_known_point(void) {
+    // 120 ohm maps to 100 C in the table
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 100.0f, temperatureFromResistance(120.0f));
+}
+
+void test_pressureFromVoltage_known_point(void) {
+    // 1.77 V maps to 3.5 bar in the table
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 3.5f, pressureFromVoltage(1.77f));
+}
+
+// ---------- temperatureBand ----------
+
+void test_temperatureBand_boundaries(void) {
+    TEST_ASSERT_EQUAL_UINT8(0, temperatureBand(69.9f));
+    TEST_ASSERT_EQUAL_UINT8(1, temperatureBand(70.0f));
+    TEST_ASSERT_EQUAL_UINT8(1, temperatureBand(89.9f));
+    TEST_ASSERT_EQUAL_UINT8(2, temperatureBand(90.0f));
+    TEST_ASSERT_EQUAL_UINT8(2, temperatureBand(109.9f));
+    TEST_ASSERT_EQUAL_UINT8(3, temperatureBand(110.0f));
+    TEST_ASSERT_EQUAL_UINT8(3, temperatureBand(122.0f));
+    TEST_ASSERT_EQUAL_UINT8(4, temperatureBand(122.1f));
+}
+
+// ---------- low-pressure alarm hysteresis (§4, 70-89 band: crit 0.9 / rearm 1.1) ----------
+
+void test_lowPressAlarm_trips_below_critical(void) {
+    TEST_ASSERT_TRUE(nextLowPressAlarm(false, 80.0f, 0.8f)); // below 0.9 -> trip
+}
+
+void test_lowPressAlarm_stays_off_above_critical(void) {
+    TEST_ASSERT_FALSE(nextLowPressAlarm(false, 80.0f, 1.0f)); // above 0.9, not tripped
+}
+
+void test_lowPressAlarm_holds_in_hysteresis_band(void) {
+    // already tripped, pressure recovered to 1.0 (between crit 0.9 and rearm 1.1) -> stays on
+    TEST_ASSERT_TRUE(nextLowPressAlarm(true, 80.0f, 1.0f));
+}
+
+void test_lowPressAlarm_clears_at_rearm(void) {
+    TEST_ASSERT_FALSE(nextLowPressAlarm(true, 80.0f, 1.1f)); // >= rearm -> clear
+}
+
+// ---------- evaluateSituation: each branch (valid sensors: R=100, V=2.0) ----------
+
+void test_situation_temp_sensor_err(void) {
+    TEST_ASSERT_EQUAL(SIT_TEMP_SENSOR_ERR, evaluateSituation(1500.0f, 2.0f, 130.0f, 1.0f, true));
+}
+
+void test_situation_press_sensor_err(void) {
+    TEST_ASSERT_EQUAL(SIT_PRESS_SENSOR_ERR, evaluateSituation(100.0f, 0.2f, 80.0f, 3.0f, false));
+}
+
+void test_situation_stop_engine(void) {
+    TEST_ASSERT_EQUAL(SIT_STOP_ENGINE, evaluateSituation(100.0f, 2.0f, 130.0f, 1.0f, false));
+}
+
+void test_situation_low_pressure(void) {
+    TEST_ASSERT_EQUAL(SIT_LOW_PRESSURE, evaluateSituation(100.0f, 2.0f, 80.0f, 2.0f, true));
+}
+
+void test_situation_overpressure(void) {
+    TEST_ASSERT_EQUAL(SIT_OVERPRESSURE, evaluateSituation(100.0f, 2.0f, 80.0f, 7.0f, false));
+}
+
+void test_situation_mild_overheat(void) {
+    TEST_ASSERT_EQUAL(SIT_MILD_OVERHEAT, evaluateSituation(100.0f, 2.0f, 115.0f, 3.0f, false));
+}
+
+void test_situation_regulation(void) {
+    TEST_ASSERT_EQUAL(SIT_REGULATION, evaluateSituation(100.0f, 2.0f, 100.0f, 3.0f, false));
+}
+
+void test_situation_normal(void) {
+    TEST_ASSERT_EQUAL(SIT_NORMAL, evaluateSituation(100.0f, 2.0f, 80.0f, 3.0f, false));
+}
+
+void test_situation_cold(void) {
+    TEST_ASSERT_EQUAL(SIT_COLD, evaluateSituation(100.0f, 2.0f, 50.0f, 3.0f, false));
+}
+
+// ---------- evaluateSituation: priority masking ----------
+
+void test_priority_temp_err_beats_stop_engine(void) {
+    // both temp fault and stop-engine conditions true -> temp fault wins
+    TEST_ASSERT_EQUAL(SIT_TEMP_SENSOR_ERR, evaluateSituation(1500.0f, 2.0f, 130.0f, 1.0f, true));
+}
+
+void test_priority_stop_engine_beats_low_pressure(void) {
+    // stop-engine and lowPressAlarm both true -> stop engine wins
+    TEST_ASSERT_EQUAL(SIT_STOP_ENGINE, evaluateSituation(100.0f, 2.0f, 130.0f, 1.0f, true));
+}
+
+void test_priority_low_pressure_beats_overpressure(void) {
+    // lowPressAlarm set and pressure also over ceiling -> low pressure wins (checked first)
+    TEST_ASSERT_EQUAL(SIT_LOW_PRESSURE, evaluateSituation(100.0f, 2.0f, 80.0f, 7.0f, true));
+}
+
+// ---------- nextFlapState ----------
+
+void test_flap_safety_forces_open(void) {
+    TEST_ASSERT_TRUE(nextFlapState(SIT_STOP_ENGINE, 50.0f, false));
+    TEST_ASSERT_TRUE(nextFlapState(SIT_LOW_PRESSURE, 50.0f, false));
+    TEST_ASSERT_TRUE(nextFlapState(SIT_MILD_OVERHEAT, 50.0f, false));
+    TEST_ASSERT_TRUE(nextFlapState(SIT_TEMP_SENSOR_ERR, 50.0f, false));
+    TEST_ASSERT_TRUE(nextFlapState(SIT_PRESS_SENSOR_ERR, 50.0f, false));
+}
+
+void test_flap_overpressure_holds_state(void) {
+    TEST_ASSERT_FALSE(nextFlapState(SIT_OVERPRESSURE, 130.0f, false)); // stays closed
+    TEST_ASSERT_TRUE(nextFlapState(SIT_OVERPRESSURE, 50.0f, true));    // stays open
+}
+
+void test_flap_hysteresis_opens_at_92(void) {
+    TEST_ASSERT_FALSE(nextFlapState(SIT_REGULATION, 91.0f, false)); // not yet
+    TEST_ASSERT_TRUE(nextFlapState(SIT_REGULATION, 92.0f, false));  // opens at 92
+}
+
+void test_flap_hysteresis_closes_at_85(void) {
+    TEST_ASSERT_TRUE(nextFlapState(SIT_NORMAL, 86.0f, true));   // holds open
+    TEST_ASSERT_FALSE(nextFlapState(SIT_NORMAL, 85.0f, true));  // closes at 85
+}
+
+void test_flap_hysteresis_holds_between(void) {
+    TEST_ASSERT_FALSE(nextFlapState(SIT_NORMAL, 88.0f, false)); // stays closed
+    TEST_ASSERT_TRUE(nextFlapState(SIT_REGULATION, 90.0f, true)); // stays open
+}
+
+// ---------- situationAlert ----------
+
+void test_alert_levels(void) {
+    TEST_ASSERT_EQUAL(ALERT_ALARM, situationAlert(SIT_STOP_ENGINE));
+    TEST_ASSERT_EQUAL(ALERT_ALARM, situationAlert(SIT_LOW_PRESSURE));
+    TEST_ASSERT_EQUAL(ALERT_ALARM, situationAlert(SIT_OVERPRESSURE));
+    TEST_ASSERT_EQUAL(ALERT_ALARM, situationAlert(SIT_TEMP_SENSOR_ERR));
+    TEST_ASSERT_EQUAL(ALERT_WARN,  situationAlert(SIT_MILD_OVERHEAT));
+    TEST_ASSERT_EQUAL(ALERT_OFF,   situationAlert(SIT_REGULATION));
+    TEST_ASSERT_EQUAL(ALERT_OFF,   situationAlert(SIT_NORMAL));
+    TEST_ASSERT_EQUAL(ALERT_OFF,   situationAlert(SIT_COLD));
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_interpolate_below_range_clamps_low);
+    RUN_TEST(test_interpolate_above_range_clamps_high);
+    RUN_TEST(test_interpolate_exact_knot);
+    RUN_TEST(test_interpolate_midpoint);
+
+    RUN_TEST(test_temperatureFromResistance_fault_clamps_to_max);
+    RUN_TEST(test_temperatureFromResistance_known_point);
+    RUN_TEST(test_pressureFromVoltage_known_point);
+
+    RUN_TEST(test_temperatureBand_boundaries);
+
+    RUN_TEST(test_lowPressAlarm_trips_below_critical);
+    RUN_TEST(test_lowPressAlarm_stays_off_above_critical);
+    RUN_TEST(test_lowPressAlarm_holds_in_hysteresis_band);
+    RUN_TEST(test_lowPressAlarm_clears_at_rearm);
+
+    RUN_TEST(test_situation_temp_sensor_err);
+    RUN_TEST(test_situation_press_sensor_err);
+    RUN_TEST(test_situation_stop_engine);
+    RUN_TEST(test_situation_low_pressure);
+    RUN_TEST(test_situation_overpressure);
+    RUN_TEST(test_situation_mild_overheat);
+    RUN_TEST(test_situation_regulation);
+    RUN_TEST(test_situation_normal);
+    RUN_TEST(test_situation_cold);
+
+    RUN_TEST(test_priority_temp_err_beats_stop_engine);
+    RUN_TEST(test_priority_stop_engine_beats_low_pressure);
+    RUN_TEST(test_priority_low_pressure_beats_overpressure);
+
+    RUN_TEST(test_flap_safety_forces_open);
+    RUN_TEST(test_flap_overpressure_holds_state);
+    RUN_TEST(test_flap_hysteresis_opens_at_92);
+    RUN_TEST(test_flap_hysteresis_closes_at_85);
+    RUN_TEST(test_flap_hysteresis_holds_between);
+
+    RUN_TEST(test_alert_levels);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
Adds host-native unit tests for the oil-monitor decision logic, plus the refactor that makes them possible.

## What
- **`lib/decision/`** (new) — extracts the pure decision logic out of `main.cpp`: situation matrix (§3), flap & low-pressure hysteresis (§4–§5), interpolation, sensor conversions, alert mapping. Arduino-free; state passed in as parameters (no globals), so it builds and runs on the host.
- **`src/main.cpp`** — now owns hardware I/O + state and calls the pure functions. **No behaviour change.**
- **`platformio.ini`** — new `[env:native]` (Unity framework, `build_src_filter = -<*>` to skip the Arduino sources).
- **`test/test_decision/`** (new) — 30 Unity test cases.
- **`CLAUDE.md`** — updated commands/architecture; convention note to keep `lib/decision` Arduino-free and add tests with new decision logic.

## Coverage (`pio test -e native`)
- `interpolate` (clamp/knot/midpoint), sensor conversions
- `temperatureBand` boundaries (70/90/110/122)
- low-pressure hysteresis: trip / hold-in-band / rearm (§4)
- flap hysteresis: open@92 / close@85 / hold / safety-force-open / overpressure-hold (§5)
- situation matrix: every situation + priority masking (temp-err > stop-engine > low-press > overpressure)
- alert-level mapping

## Verification
- `pio test -e native` → **30/30 passed**
- `pio run -e bluepill_f103c8` → builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)