### PR TITLE
docs: rewrite README for current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,103 @@
+# STM-Auto — SWEE.BRZ Oil Monitor
 
-# STM-Auto: Oil Monitor System
+[![CI](https://github.com/raphaeltournafond/STM-Auto/actions/workflows/ci.yml/badge.svg)](https://github.com/raphaeltournafond/STM-Auto/actions/workflows/ci.yml)
 
-This is a temperature monitoring system for the SWEE.BRZ vehicle using an STM32 Blue Pill microcontroller.
+Firmware for an oil **temperature** and **pressure** monitor on an STM32F103C8T6 "Blue Pill",
+built with PlatformIO + the Arduino-STM32 core. It reads the two sensors, regulates oil temperature
+by opening/closing **twin flap servos**, raises tiered alerts, and shows live status on a 128×64
+SSD1306 OLED.
 
-## Overview
+The full behavioural specification (life phases, the priority-ordered situation matrix, adaptive
+pressure floors, hysteresis, acknowledgement and voice messages) lives in
+[`DECISION_MATRIX.md`](DECISION_MATRIX.md).
 
-This project monitors oil temperature via a resistance-based sensor and automatically controls a servo-driven flap valve based on temperature thresholds. Status is displayed on a 128x64 OLED screen.
+## Features
+
+- **Dual sensing** — oil temperature (resistance → °C) and pressure (voltage → bar), via
+  piecewise-linear sensor scales.
+- **Thermal regulation** — twin flap servos driven in tandem, with temperature hysteresis
+  (open 92 °C / close 85 °C) to avoid chatter.
+- **Situation decision matrix** — every cycle picks the single highest-priority situation
+  (sensor faults → stop-engine → low pressure → overpressure → overheat → normal bands) and drives
+  the outputs accordingly, including an **adaptive low-pressure floor** that depends on the
+  temperature band.
+- **Fail-safes** — flap defaults open on any doubt; sensor faults are detected on the raw signal
+  (resistance / voltage) before conversion.
+- **Status display** — temperature, pressure, flap state and alert banner on the OLED, plus an
+  onboard backup alert LED.
+- **Tested** — pure decision logic is unit-tested on the host and gated by CI.
 
 ## Hardware
 
-- **MCU**: STM32F103C8 (Blue Pill)
-- **Display**: SSD1306 OLED (128x64) via I2C
-- **Sensor**: Temperature resistor on PA1
-- **Actuator**: Servo motor on PA6
-- **Connections**:
-  - OLED SDA: PB11
-  - OLED SCL: PB10
+- **MCU:** STM32F103C8T6 "Blue Pill"
+- **Display:** SSD1306 OLED 128×64 (I²C)
+- **Programmer:** ST-Link (`upload_protocol = stlink`)
 
-## Configuration
+Pin map (source of truth: [`src/pins.h`](src/pins.h)):
 
-Key parameters in `main.cpp`:
+| Function | Pin(s) | Function | Pin(s) |
+|---|---|---|---|
+| Pressure sensor | `PA0` | Buzzer (`tone()` → TIM3) | `PB6` |
+| Temperature sensor | `PA1` | OLED SCL / SDA (I2C2) | `PB10` / `PB11` |
+| Flap servos ×2 (`Servo` → TIM2) | `PA6` / `PA7` | WS2812B RGB LED (SPI2 MOSI+DMA) | `PB15` |
+| MP3 module (USART1) | `PA9` / `PA10` | Onboard backup LED | `PC13` |
+| CAN RX / TX | `PA11` / `PA12` | ACK touch button | `PB5` |
 
-- `TEMP_RESISTANCE_THRESHOLD`: Temperature threshold for flap control (default: 1000 Ω)
-- `TEMP_SERIES_RESISTOR`: Series resistor value (default: 220 Ω)
-- Servo angles: Closed (0°), Open (90°)
+Per-peripheral wiring decisions (supply rails, level handling, supporting parts) are documented in
+[`kicad/stm-auto/WIRING.md`](kicad/stm-auto/WIRING.md).
 
-## Building & Uploading
+## Getting started
+
+Requires [PlatformIO](https://platformio.org/).
 
 ```bash
-platformio run -e bluepill_f103c8 -t upload
+pio run -e bluepill_f103c8            # build firmware
+pio run -e bluepill_f103c8 -t upload  # flash via ST-Link
+pio device monitor -b 115200          # serial monitor @ 115200 baud
+pio test -e native                    # run unit tests on the host (no hardware)
+pio run -t clean                      # clean
 ```
 
-Monitor serial output at 115200 baud.
+Library dependencies (auto-installed): Adafruit SSD1306 + Adafruit GFX (firmware), Unity (tests).
 
-## Dependencies
+## Architecture
 
-- Adafruit SSD1306
-- Adafruit GFX Library
-- Arduino framework for STM32
+- **`lib/decision/`** — the decision logic as **pure, Arduino-free functions** (situation matrix,
+  hysteresis state machines, interpolation, sensor conversions). State is passed in as parameters,
+  so it builds and runs natively and is fully unit-testable.
+- **`src/main.cpp`** — owns all hardware I/O (servos, OLED, ADC, LED, serial) and the evolving
+  state, calling into `lib/decision` each 200 ms loop.
+
+```
+src/            firmware (main.cpp, pins.h)
+lib/decision/   pure decision logic (unit-tested)
+test/           Unity test suites (native)
+kicad/stm-auto/ schematic, PCB, wiring notes
+```
+
+## Tests & CI
+
+The pure decision logic has a host-native test suite (Unity):
+
+```bash
+pio test -e native
+```
+
+[GitHub Actions](.github/workflows/ci.yml) runs the unit tests and the firmware build on every pull
+request and on pushes to `main`.
+
+## Status
+
+**Implemented:** temperature + pressure reading, twin-servo thermal regulation with hysteresis, the
+full situation decision matrix with adaptive low-pressure floor, OLED status display, onboard backup
+alert LED, native tests + CI.
+
+**Wired but not yet coded** (pins assigned, schematic complete): WS2812B RGB indicator, buzzer tone
+patterns, MP3 voice prompts, ACK touch button, CAN / engine-RPM input. See `DECISION_MATRIX.md` for
+the roadmap.
 
 ## Schematics
 
-The kicad project [is available here](kicad/stm-auto/)
+The KiCad project is [available here](kicad/stm-auto/).
 
-![Schematics image](kicad/stm-auto/stm-auto.svg)
+![Schematic](kicad/stm-auto/stm-auto.svg)


### PR DESCRIPTION
Replaces the stale README (temperature-only, single servo, a config constant that no longer exists) with an accurate, complete overview.

## What
- **Scope** — dual temperature + pressure sensing, twin-servo thermal regulation with hysteresis, the priority-ordered situation decision matrix with adaptive low-pressure floor.
- **CI badge** at the top.
- **Full pin-map table** (source: `src/pins.h`) and a link to `kicad/stm-auto/WIRING.md` for per-peripheral wiring decisions.
- **Getting-started** commands incl. `pio test -e native`.
- **Architecture** — `lib/decision` (pure, tested) vs `src/main.cpp` (hardware + state), with a layout tree.
- **Tests & CI** section, and an honest **implemented vs. wired-but-not-coded** status.
- Links to `DECISION_MATRIX.md`, the CI workflow, and the schematic image (preserved).

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)