### PR TITLE
feat: drive WS2812B RGB alert indicator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,24 +26,26 @@ Libs (`platformio.ini`): Adafruit SSD1306 + GFX (firmware); Unity (native tests,
 
 ## Architecture
 
-Decision logic lives in `lib/decision/` (pure, Arduino-free, unit-tested); `src/main.cpp` owns
-hardware I/O and state and calls into it:
+Pure logic lives in `lib/` (Arduino-free, unit-tested); `src/main.cpp` owns hardware I/O and state
+and calls into it:
 
 - **`lib/decision/decision.{h,cpp}`** — `evaluateSituation()` (priority matrix §3), `nextFlapState()`
   (§5 hysteresis), `nextLowPressAlarm()` (§4), `temperatureBand()`, `situationAlert()`,
   `interpolate()` and the sensor scale tables. All pure functions taking state as parameters.
+- **`lib/ws2812/ws2812.{h,cpp}`** — `alertColor()` and `encodePixelGRB()` (one WS2812B pixel → 9 SPI
+  bytes, 3 SPI bits per WS bit). Pure; the SPI2 transmit lives in `main.cpp` (`ws2812Send()`).
 - `setup()` — serial @115200, status LED, OLED init (blocks in `blinkErrorLED()` on failure),
-  servo attach + close, 12-bit ADC.
+  servo attach + close, WS2812B (SPI2) init, 12-bit ADC.
 - `loop()` @200 ms — read sensors, then run the decision functions and dispatch outputs:
-  `applyFlap()` (twin servos), `applyAlertLed()` (onboard backup LED), `onSituationChange()`
+  `applyFlap()` (twin servos), `applyAlertLed()` (WS2812B primary + PC13 backup), `onSituationChange()`
   (edge-triggered sound/voice — stubbed), and `updateDisplay()`. `main.cpp` holds the evolving
   state (`flapOpen`, `lowPressAlarm`, `prevSituation`).
-- **Tests**: `test/test_decision/` (Unity) run via `pio test -e native` against `lib/decision` —
-  the `native` env excludes `src/` so no hardware/toolchain is needed.
+- **Tests**: `test/test_*/` (Unity) run via `pio test -e native` against `lib/` — the `native` env
+  excludes `src/` so no hardware/toolchain is needed.
 
 **Conventions to preserve:**
-- `lib/decision` stays Arduino-free (pure functions, state passed in) so it builds natively — keep
-  hardware (Servo/OLED/ADC/tone) in `src/main.cpp`. Add a test when you add decision logic.
+- `lib/` modules stay Arduino-free (pure functions, state passed in) so they build natively — keep
+  hardware (Servo/OLED/ADC/SPI/tone) in `src/main.cpp`. Add a test when you add logic.
 - Interpolation x-tables (`resTable`, `vPressureTable` in `lib/decision/decision.cpp`) **must stay
   strictly increasing**, each in sync with its y-table (`tempTable`, `barTable`) — `interpolate()`
   assumes it.
@@ -64,7 +66,7 @@ Notes: `Servo` lib owns **TIM2**, `tone()` owns **TIM3** (shared timers — don'
 CAN uses the USB pins → remove the PA12 USB pull-up. WS2812B needs a level shifter (or ~4.3V supply).
 
 `main.cpp` includes `pins.h` and uses these macros directly — change a pin in `pins.h` only.
-Wired but not yet coded: MP3, buzzer, button, WS2812B, CAN.
+Wired but not yet coded: MP3, buzzer, button, CAN.
 
 ## Layout & workflow
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ Library dependencies (auto-installed): Adafruit SSD1306 + Adafruit GFX (firmware
 
 ## Architecture
 
-- **`lib/decision/`** — the decision logic as **pure, Arduino-free functions** (situation matrix,
-  hysteresis state machines, interpolation, sensor conversions). State is passed in as parameters,
-  so it builds and runs natively and is fully unit-testable.
-- **`src/main.cpp`** — owns all hardware I/O (servos, OLED, ADC, LED, serial) and the evolving
-  state, calling into `lib/decision` each 200 ms loop.
+- **`lib/`** — **pure, Arduino-free** logic: `decision/` (situation matrix, hysteresis, interpolation,
+  sensor conversions) and `ws2812/` (WS2812B pixel → SPI byte encoding). State is passed in as
+  parameters, so it builds and runs natively and is fully unit-testable.
+- **`src/main.cpp`** — owns all hardware I/O (servos, OLED, ADC, LEDs, SPI, serial) and the evolving
+  state, calling into `lib/` each 200 ms loop.
 
 ```
 src/            firmware (main.cpp, pins.h)
-lib/decision/   pure decision logic (unit-tested)
+lib/            pure libraries (decision, ws2812) — unit-tested
 test/           Unity test suites (native)
 kicad/stm-auto/ schematic, PCB, wiring notes
 ```
@@ -89,12 +89,11 @@ request and on pushes to `main`.
 ## Status
 
 **Implemented:** temperature + pressure reading, twin-servo thermal regulation with hysteresis, the
-full situation decision matrix with adaptive low-pressure floor, OLED status display, onboard backup
-alert LED, native tests + CI.
+full situation decision matrix with adaptive low-pressure floor, OLED status display, WS2812B RGB
+alert indicator (off/yellow/red) with onboard backup LED, native tests + CI.
 
-**Wired but not yet coded** (pins assigned, schematic complete): WS2812B RGB indicator, buzzer tone
-patterns, MP3 voice prompts, ACK touch button, CAN / engine-RPM input. See `DECISION_MATRIX.md` for
-the roadmap.
+**Wired but not yet coded** (pins assigned, schematic complete): buzzer tone patterns, MP3 voice
+prompts, ACK touch button, CAN / engine-RPM input. See `DECISION_MATRIX.md` for the roadmap.
 
 ## Schematics
 

--- a/lib/ws2812/ws2812.cpp
+++ b/lib/ws2812/ws2812.cpp
@@ -1,0 +1,29 @@
+#include "ws2812.h"
+
+// Moderate brightness so a cabin status LED is clearly visible but not blinding.
+static const uint8_t LVL = 64;
+
+Rgb alertColor(AlertLevel level) {
+    switch (level) {
+        case ALERT_ALARM: return {LVL, 0, 0};   // red
+        case ALERT_WARN:  return {LVL, LVL, 0};  // yellow
+        default:          return {0, 0, 0};      // off
+    }
+}
+
+// One WS2812 data byte -> 3 SPI bytes (24 SPI bits, MSB-first).
+static void encodeByte(uint8_t value, uint8_t* out) {
+    uint32_t bits = 0;
+    for (int8_t i = 7; i >= 0; i--) {
+        bits = (bits << 3) | (((value >> i) & 1u) ? 0b110u : 0b100u);
+    }
+    out[0] = (bits >> 16) & 0xFF;
+    out[1] = (bits >> 8) & 0xFF;
+    out[2] = bits & 0xFF;
+}
+
+void encodePixelGRB(const Rgb& c, uint8_t* out) {
+    encodeByte(c.g, out);      // WS2812B wire order is G, R, B
+    encodeByte(c.r, out + 3);
+    encodeByte(c.b, out + 6);
+}

--- a/lib/ws2812/ws2812.h
+++ b/lib/ws2812/ws2812.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <stdint.h>
+#include "decision.h" // AlertLevel
+
+// WS2812B pixel encoding for transmission over an SPI MOSI line.
+// Each WS2812 data bit is sent as 3 SPI bits at ~2.4 MHz: '0' -> 0b100,
+// '1' -> 0b110 (high ~0.4 us / ~0.8 us, within the WS2812B timing window).
+// One pixel (GRB, 24 bits) -> 9 SPI bytes, MSB-first. The encoded stream always
+// ends in a 0 bit, so the line idles low for the >50 us reset/latch gap.
+//
+// Pure / hardware-independent so it can be unit-tested natively.
+
+struct Rgb { uint8_t r, g, b; };
+
+constexpr uint8_t WS2812_PIXEL_BYTES = 9; // SPI bytes per WS2812B pixel
+
+// Indicator colour for an alert level (DECISION_MATRIX LED column: off/yellow/red).
+Rgb alertColor(AlertLevel level);
+
+// Encode one pixel (GRB order) into WS2812_PIXEL_BYTES SPI bytes (out[9]).
+void encodePixelGRB(const Rgb& c, uint8_t* out);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,8 +3,10 @@
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
+#include <SPI.h>
 #include "pins.h"      // pin map (single source of truth)
 #include "decision.h"  // hardware-independent decision logic (unit-tested)
+#include "ws2812.h"    // WS2812B pixel encoding (unit-tested)
 
 // ========== CONFIGURATION ==========
 
@@ -33,6 +35,24 @@ Servo flapServo2;
 bool flapOpen = false;      // current flap state (hysteresis), starts closed
 bool lowPressAlarm = false; // adaptive low-pressure alarm state (§4)
 int prevSituation = -1;     // last dispatched situation (edge-triggered sound/voice)
+
+// ----- WS2812B RGB LED (primary indicator) -----
+// Driven over SPI2 MOSI (PIN_WS2812_DATA); SCLK/MISO are SPI2's other pins,
+// unused/unconnected. Each WS2812 bit is 3 SPI bits at ~2.4 MHz (see lib/ws2812).
+// A blocking 9-byte transfer is IRQ-safe (no bit-banging) and ample for one pixel.
+SPIClass WS2812_SPI(PIN_WS2812_DATA, PB14, PB13); // MOSI, (MISO), (SCLK)
+
+void ws2812Send(const uint8_t* buf, uint8_t len) {
+    WS2812_SPI.beginTransaction(SPISettings(2400000, MSBFIRST, SPI_MODE0));
+    for (uint8_t i = 0; i < len; i++) WS2812_SPI.transfer(buf[i]);
+    WS2812_SPI.endTransaction();
+}
+
+void ws2812ShowAlert(AlertLevel level) {
+    uint8_t buf[WS2812_PIXEL_BYTES];
+    encodePixelGRB(alertColor(level), buf);
+    ws2812Send(buf, sizeof(buf));
+}
 
 
 // ========== SETUP ==========
@@ -66,6 +86,10 @@ void setup() {
     flapServo1.write(FLAP_CLOSED);
     flapServo2.write(FLAP_CLOSED);
 
+    // ----- WS2812B initialization -----
+    WS2812_SPI.begin();
+    ws2812ShowAlert(ALERT_OFF); // start dark
+
     // ----- OTHER Settings -----
     analogReadResolution(12);
 }
@@ -98,9 +122,10 @@ void applyFlap(bool open) {
 }
 
 // ----- LED -----
-// Onboard PC13 (active LOW) used as the backup indicator: lit on any alert.
-// TODO: drive WS2812B (PIN_WS2812_DATA) as the primary off/yellow/red indicator.
+// Primary indicator: WS2812B (off/yellow/red). Onboard PC13 (active LOW) mirrors
+// it as a backup: lit on any alert, off otherwise.
 void applyAlertLed(AlertLevel level) {
+    ws2812ShowAlert(level);
     digitalWrite(PIN_STATUS_LED, level == ALERT_OFF ? HIGH : LOW);
 }
 

--- a/test/test_ws2812/test_ws2812.cpp
+++ b/test/test_ws2812/test_ws2812.cpp
@@ -1,0 +1,63 @@
+#include <unity.h>
+#include "ws2812.h"
+
+// Native unit tests for the WS2812B encoding (lib/ws2812).
+// Run: pio test -e native
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// 3-SPI-bit codes: data 0 -> 0b100, data 1 -> 0b110.
+// A 0x00 byte -> 100100100100100100100100 -> 0x92 0x49 0x24
+// A 0xFF byte -> 110110110110110110110110 -> 0xDB 0x6D 0xB6
+static const uint8_t ZERO_BYTE[3] = {0x92, 0x49, 0x24};
+static const uint8_t FF_BYTE[3]   = {0xDB, 0x6D, 0xB6};
+
+void test_encode_all_zero(void) {
+    uint8_t out[WS2812_PIXEL_BYTES];
+    encodePixelGRB(Rgb{0, 0, 0}, out);
+    for (uint8_t i = 0; i < 9; i++) TEST_ASSERT_EQUAL_HEX8(ZERO_BYTE[i % 3], out[i]);
+}
+
+void test_encode_all_full(void) {
+    uint8_t out[WS2812_PIXEL_BYTES];
+    encodePixelGRB(Rgb{255, 255, 255}, out);
+    for (uint8_t i = 0; i < 9; i++) TEST_ASSERT_EQUAL_HEX8(FF_BYTE[i % 3], out[i]);
+}
+
+void test_encode_grb_order(void) {
+    // Pure red: R=0xFF, G=0x00, B=0x00. Wire order G,R,B -> zero, full, zero.
+    uint8_t out[WS2812_PIXEL_BYTES];
+    encodePixelGRB(Rgb{255, 0, 0}, out);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(ZERO_BYTE, &out[0], 3); // G
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(FF_BYTE,   &out[3], 3); // R
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(ZERO_BYTE, &out[6], 3); // B
+}
+
+void test_encoded_stream_ends_low(void) {
+    // Last SPI bit must be 0 so the line idles low for the reset/latch.
+    uint8_t out[WS2812_PIXEL_BYTES];
+    encodePixelGRB(Rgb{123, 200, 45}, out);
+    TEST_ASSERT_EQUAL_UINT8(0, out[WS2812_PIXEL_BYTES - 1] & 0x01);
+}
+
+void test_alert_colors(void) {
+    Rgb off = alertColor(ALERT_OFF);
+    TEST_ASSERT_EQUAL_UINT8(0, off.r); TEST_ASSERT_EQUAL_UINT8(0, off.g); TEST_ASSERT_EQUAL_UINT8(0, off.b);
+
+    Rgb warn = alertColor(ALERT_WARN);   // yellow: R and G on, B off
+    TEST_ASSERT_TRUE(warn.r > 0); TEST_ASSERT_TRUE(warn.g > 0); TEST_ASSERT_EQUAL_UINT8(0, warn.b);
+
+    Rgb alarm = alertColor(ALERT_ALARM); // red: R on, G and B off
+    TEST_ASSERT_TRUE(alarm.r > 0); TEST_ASSERT_EQUAL_UINT8(0, alarm.g); TEST_ASSERT_EQUAL_UINT8(0, alarm.b);
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_encode_all_zero);
+    RUN_TEST(test_encode_all_full);
+    RUN_TEST(test_encode_grb_order);
+    RUN_TEST(test_encoded_stream_ends_low);
+    RUN_TEST(test_alert_colors);
+    return UNITY_END();
+}


### PR DESCRIPTION
Brings the primary status indicator to life: the WS2812B now shows the situation alert level as off / yellow / red.

## What
- **`lib/ws2812/`** (new, pure, unit-tested):
  - `alertColor(AlertLevel)` → off / yellow / red.
  - `encodePixelGRB()` → one WS2812B pixel into 9 SPI bytes (3 SPI bits per WS bit, MSB-first; the stream always ends in a 0 bit so the line idles low for the >50 µs reset/latch).
- **`src/main.cpp`**:
  - `ws2812Send()` transmits over **SPI2 MOSI (PB15)** with a blocking 9-byte transfer (~32 µs, IRQ-safe, no bit-banging — no DMA needed for a single pixel).
  - `applyAlertLed()` now drives the WS2812B as the primary indicator with PC13 as a backup; initialized dark in `setup()`.
- Docs: `CLAUDE.md` + `README.md` updated (WS2812B moved to implemented; `lib/ws2812` documented).

## Coverage
5 new native tests (zero/full byte patterns → `0x92 0x49 0x24` / `0xDB 0x6D 0xB6`, GRB ordering, stream-ends-low, colour mapping). Total **35/35**.

## Verification
- `pio test -e native` → 35/35 passed
- `pio run -e bluepill_f103c8` → builds clean (Flash 59.4%)
- Note: SPI *timing* can't be verified without hardware — recommend a quick bench check that colours render correctly after flashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)