### PR TITLE
feat: drive buzzer alert patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,14 @@ and calls into it:
   `interpolate()` and the sensor scale tables. All pure functions taking state as parameters.
 - **`lib/ws2812/ws2812.{h,cpp}`** — `alertColor()` and `encodePixelGRB()` (one WS2812B pixel → 9 SPI
   bytes, 3 SPI bits per WS bit). Pure; the SPI2 transmit lives in `main.cpp` (`ws2812Send()`).
+- **`lib/buzzer/buzzer.{h,cpp}`** — `buzzerPattern()` (situation → §3 sound pattern) and `buzzerOnAt()`
+  (periodic on/off envelope). Pure; `tone()` drive lives in `main.cpp` (`applyBuzzer()`).
 - `setup()` — serial @115200, status LED, OLED init (blocks in `blinkErrorLED()` on failure),
   servo attach + close, WS2812B (SPI2) init, 12-bit ADC.
 - `loop()` @200 ms — read sensors, then run the decision functions and dispatch outputs:
-  `applyFlap()` (twin servos), `applyAlertLed()` (WS2812B primary + PC13 backup), `onSituationChange()`
-  (edge-triggered sound/voice — stubbed), and `updateDisplay()`. `main.cpp` holds the evolving
-  state (`flapOpen`, `lowPressAlarm`, `prevSituation`).
+  `applyFlap()` (twin servos), `applyAlertLed()` (WS2812B primary + PC13 backup), `applyBuzzer()`
+  (piezo via `tone()`), `onSituationChange()` (edge-triggered voice — stubbed), and `updateDisplay()`.
+  `main.cpp` holds the evolving state (`flapOpen`, `lowPressAlarm`, `buzzerSounding`, `prevSituation`).
 - **Tests**: `test/test_*/` (Unity) run via `pio test -e native` against `lib/` — the `native` env
   excludes `src/` so no hardware/toolchain is needed.
 
@@ -66,7 +68,7 @@ Notes: `Servo` lib owns **TIM2**, `tone()` owns **TIM3** (shared timers — don'
 CAN uses the USB pins → remove the PA12 USB pull-up. WS2812B needs a level shifter (or ~4.3V supply).
 
 `main.cpp` includes `pins.h` and uses these macros directly — change a pin in `pins.h` only.
-Wired but not yet coded: MP3, buzzer, button, CAN.
+Wired but not yet coded: MP3, button, CAN.
 
 ## Layout & workflow
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Library dependencies (auto-installed): Adafruit SSD1306 + Adafruit GFX (firmware
 ## Architecture
 
 - **`lib/`** — **pure, Arduino-free** logic: `decision/` (situation matrix, hysteresis, interpolation,
-  sensor conversions) and `ws2812/` (WS2812B pixel → SPI byte encoding). State is passed in as
-  parameters, so it builds and runs natively and is fully unit-testable.
+  sensor conversions), `ws2812/` (WS2812B pixel → SPI byte encoding), and `buzzer/` (alert patterns +
+  envelope). State is passed in as parameters, so it builds and runs natively and is fully unit-testable.
 - **`src/main.cpp`** — owns all hardware I/O (servos, OLED, ADC, LEDs, SPI, serial) and the evolving
   state, calling into `lib/` each 200 ms loop.
 
@@ -90,10 +90,10 @@ request and on pushes to `main`.
 
 **Implemented:** temperature + pressure reading, twin-servo thermal regulation with hysteresis, the
 full situation decision matrix with adaptive low-pressure floor, OLED status display, WS2812B RGB
-alert indicator (off/yellow/red) with onboard backup LED, native tests + CI.
+alert indicator (off/yellow/red) with onboard backup LED, buzzer alert patterns, native tests + CI.
 
-**Wired but not yet coded** (pins assigned, schematic complete): buzzer tone patterns, MP3 voice
-prompts, ACK touch button, CAN / engine-RPM input. See `DECISION_MATRIX.md` for the roadmap.
+**Wired but not yet coded** (pins assigned, schematic complete): MP3 voice prompts, ACK touch button,
+CAN / engine-RPM input. See `DECISION_MATRIX.md` for the roadmap.
 
 ## Schematics
 

--- a/lib/buzzer/buzzer.cpp
+++ b/lib/buzzer/buzzer.cpp
@@ -1,0 +1,29 @@
+#include "buzzer.h"
+
+// Envelope timings (ms). Kept as multiples of the ~200 ms main loop so the
+// coarse sampling rate reproduces them cleanly.
+static const uint32_t INTERMITTENT_ON     = 400;
+static const uint32_t INTERMITTENT_PERIOD = 800;  // 400 on / 400 off
+static const uint32_t LONG_ON             = 800;
+static const uint32_t LONG_PERIOD         = 1200; // 800 on / 400 off
+
+BuzzerPattern buzzerPattern(Situation sit) {
+    switch (sit) {
+        case SIT_STOP_ENGINE:
+        case SIT_LOW_PRESSURE:
+        case SIT_OVERPRESSURE:     return BUZZ_CONTINUOUS;
+        case SIT_TEMP_SENSOR_ERR:
+        case SIT_PRESS_SENSOR_ERR: return BUZZ_LONG_BEEPS;
+        case SIT_MILD_OVERHEAT:    return BUZZ_INTERMITTENT;
+        default:                   return BUZZ_SILENT; // regulation / normal / cold
+    }
+}
+
+bool buzzerOnAt(BuzzerPattern pattern, uint32_t t) {
+    switch (pattern) {
+        case BUZZ_CONTINUOUS:   return true;
+        case BUZZ_INTERMITTENT: return (t % INTERMITTENT_PERIOD) < INTERMITTENT_ON;
+        case BUZZ_LONG_BEEPS:   return (t % LONG_PERIOD) < LONG_ON;
+        default:                return false; // BUZZ_SILENT
+    }
+}

--- a/lib/buzzer/buzzer.h
+++ b/lib/buzzer/buzzer.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <stdint.h>
+#include "decision.h" // Situation
+
+// Buzzer alert patterns from the DECISION_MATRIX §3 sound column.
+// Pure / hardware-independent so they can be unit-tested natively. The actual
+// tone() drive and the loop tick live in src/main.cpp.
+
+enum BuzzerPattern {
+    BUZZ_SILENT,       // situations 7-9 (regulation / normal / cold)
+    BUZZ_CONTINUOUS,   // situations 3-5 (stop engine / low pressure / overpressure)
+    BUZZ_INTERMITTENT, // situation 6 (mild overheat)
+    BUZZ_LONG_BEEPS,   // situations 1-2 (sensor faults)
+};
+
+constexpr uint16_t BUZZER_FREQ_HZ = 2700; // passive piezo drive frequency
+
+// Pattern for the active situation.
+BuzzerPattern buzzerPattern(Situation sit);
+
+// Whether the buzzer envelope is "on" at absolute time t (ms). Periodic, so the
+// caller can pass millis() directly. CONTINUOUS is always on, SILENT always off.
+bool buzzerOnAt(BuzzerPattern pattern, uint32_t t);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include "pins.h"      // pin map (single source of truth)
 #include "decision.h"  // hardware-independent decision logic (unit-tested)
 #include "ws2812.h"    // WS2812B pixel encoding (unit-tested)
+#include "buzzer.h"    // buzzer alert patterns (unit-tested)
 
 // ========== CONFIGURATION ==========
 
@@ -34,6 +35,7 @@ Servo flapServo2;
 // ----- Decision state (held here, evolved by the pure decision functions) -----
 bool flapOpen = false;      // current flap state (hysteresis), starts closed
 bool lowPressAlarm = false; // adaptive low-pressure alarm state (§4)
+bool buzzerSounding = false; // current buzzer tone on/off (avoids retriggering tone())
 int prevSituation = -1;     // last dispatched situation (edge-triggered sound/voice)
 
 // ----- WS2812B RGB LED (primary indicator) -----
@@ -129,9 +131,18 @@ void applyAlertLed(AlertLevel level) {
     digitalWrite(PIN_STATUS_LED, level == ALERT_OFF ? HIGH : LOW);
 }
 
-// ----- SOUND / VOICE (edge-triggered) -----
-// Buzzer (PIN_BUZZER) and MP3 voice (USART1) are wired but not yet driven.
-// TODO: implement buzzer patterns (§3) and voice files (§7); for now log only.
+// ----- BUZZER (per-loop envelope) -----
+// Passive piezo on PIN_BUZZER via tone() (TIM3). The pure pattern/envelope logic
+// lives in lib/buzzer; here we only gate the tone on transitions.
+void applyBuzzer(Situation sit) {
+    bool on = buzzerOnAt(buzzerPattern(sit), millis());
+    if (on && !buzzerSounding)      { tone(PIN_BUZZER, BUZZER_FREQ_HZ); buzzerSounding = true; }
+    else if (!on && buzzerSounding) { noTone(PIN_BUZZER); buzzerSounding = false; }
+}
+
+// ----- VOICE (edge-triggered) -----
+// MP3 voice (USART1) is wired but not yet driven.
+// TODO: trigger voice files (§7) on situation change; for now log only.
 void onSituationChange(Situation sit) {
     Serial.print("Situation -> ");
     Serial.println(situationName(sit));
@@ -215,6 +226,7 @@ void loop() {
     flapOpen = nextFlapState(sit, temperature, flapOpen);
     applyFlap(flapOpen);
     applyAlertLed(situationAlert(sit));
+    applyBuzzer(sit);
     if ((int)sit != prevSituation) { onSituationChange(sit); prevSituation = sit; }
     updateDisplay(sit, temperature, resistance, pressure, vPressure);
 

--- a/test/test_buzzer/test_buzzer.cpp
+++ b/test/test_buzzer/test_buzzer.cpp
@@ -1,0 +1,72 @@
+#include <unity.h>
+#include "buzzer.h"
+
+// Native unit tests for the buzzer patterns (lib/buzzer).
+// Run: pio test -e native
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ---------- pattern selection (§3 sound column) ----------
+
+void test_pattern_continuous_for_alarms(void) {
+    TEST_ASSERT_EQUAL(BUZZ_CONTINUOUS, buzzerPattern(SIT_STOP_ENGINE));
+    TEST_ASSERT_EQUAL(BUZZ_CONTINUOUS, buzzerPattern(SIT_LOW_PRESSURE));
+    TEST_ASSERT_EQUAL(BUZZ_CONTINUOUS, buzzerPattern(SIT_OVERPRESSURE));
+}
+
+void test_pattern_long_beeps_for_sensor_faults(void) {
+    TEST_ASSERT_EQUAL(BUZZ_LONG_BEEPS, buzzerPattern(SIT_TEMP_SENSOR_ERR));
+    TEST_ASSERT_EQUAL(BUZZ_LONG_BEEPS, buzzerPattern(SIT_PRESS_SENSOR_ERR));
+}
+
+void test_pattern_intermittent_for_overheat(void) {
+    TEST_ASSERT_EQUAL(BUZZ_INTERMITTENT, buzzerPattern(SIT_MILD_OVERHEAT));
+}
+
+void test_pattern_silent_for_normal_bands(void) {
+    TEST_ASSERT_EQUAL(BUZZ_SILENT, buzzerPattern(SIT_REGULATION));
+    TEST_ASSERT_EQUAL(BUZZ_SILENT, buzzerPattern(SIT_NORMAL));
+    TEST_ASSERT_EQUAL(BUZZ_SILENT, buzzerPattern(SIT_COLD));
+}
+
+// ---------- envelope scheduler ----------
+
+void test_envelope_silent_always_off(void) {
+    TEST_ASSERT_FALSE(buzzerOnAt(BUZZ_SILENT, 0));
+    TEST_ASSERT_FALSE(buzzerOnAt(BUZZ_SILENT, 1234));
+}
+
+void test_envelope_continuous_always_on(void) {
+    TEST_ASSERT_TRUE(buzzerOnAt(BUZZ_CONTINUOUS, 0));
+    TEST_ASSERT_TRUE(buzzerOnAt(BUZZ_CONTINUOUS, 5000));
+}
+
+void test_envelope_intermittent_400_on_400_off(void) {
+    TEST_ASSERT_TRUE(buzzerOnAt(BUZZ_INTERMITTENT, 0));
+    TEST_ASSERT_TRUE(buzzerOnAt(BUZZ_INTERMITTENT, 200));
+    TEST_ASSERT_FALSE(buzzerOnAt(BUZZ_INTERMITTENT, 400));
+    TEST_ASSERT_FALSE(buzzerOnAt(BUZZ_INTERMITTENT, 600));
+    TEST_ASSERT_TRUE(buzzerOnAt(BUZZ_INTERMITTENT, 800)); // next cycle
+}
+
+void test_envelope_long_beeps_800_on_400_off(void) {
+    TEST_ASSERT_TRUE(buzzerOnAt(BUZZ_LONG_BEEPS, 0));
+    TEST_ASSERT_TRUE(buzzerOnAt(BUZZ_LONG_BEEPS, 700));
+    TEST_ASSERT_FALSE(buzzerOnAt(BUZZ_LONG_BEEPS, 800));
+    TEST_ASSERT_FALSE(buzzerOnAt(BUZZ_LONG_BEEPS, 1100));
+    TEST_ASSERT_TRUE(buzzerOnAt(BUZZ_LONG_BEEPS, 1200)); // next cycle
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_pattern_continuous_for_alarms);
+    RUN_TEST(test_pattern_long_beeps_for_sensor_faults);
+    RUN_TEST(test_pattern_intermittent_for_overheat);
+    RUN_TEST(test_pattern_silent_for_normal_bands);
+    RUN_TEST(test_envelope_silent_always_off);
+    RUN_TEST(test_envelope_continuous_always_on);
+    RUN_TEST(test_envelope_intermittent_400_on_400_off);
+    RUN_TEST(test_envelope_long_beeps_800_on_400_off);
+    return UNITY_END();
+}


### PR DESCRIPTION
Drives the passive piezo buzzer with the tiered alert patterns from `DECISION_MATRIX.md` §3.

## What
- **`lib/buzzer/`** (new, pure, unit-tested):
  - `buzzerPattern(Situation)` → continuous (stop-engine / low-pressure / overpressure), long-beeps (sensor faults), intermittent (mild overheat), or silent (regulation / normal / cold).
  - `buzzerOnAt(pattern, t)` → periodic on/off envelope (CONTINUOUS always on, SILENT always off, INTERMITTENT 400/400, LONG_BEEPS 800/400).
- **`src/main.cpp`** — `applyBuzzer()` gates `tone()` on PB6 (TIM3) each loop from the envelope, tracking `buzzerSounding` to avoid retriggering the tone.
- Docs: `CLAUDE.md` + `README.md` updated (buzzer → implemented; `lib/buzzer` documented).

## Coverage
8 new native tests (pattern for every situation + envelope timing per pattern). Total **43/43**.

## Verification
- `pio test -e native` → 43/43 passed
- `pio run -e bluepill_f103c8` → builds clean

## Notes
- Envelope timings are multiples of the ~200 ms loop so the coarse sampling reproduces them cleanly; `tone()` produces the 2.7 kHz carrier in hardware.
- Audible output can't be verified without hardware — recommend a bench check of the patterns and a tweak of `BUZZER_FREQ_HZ` to the piezo's resonant peak if needed.
- Voice (MP3) remains stubbed. ACK button (which will mute the buzzer) is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)