### PR TITLE
feat: acknowledge touch button mutes alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,12 +36,16 @@ and calls into it:
   bytes, 3 SPI bits per WS bit). Pure; the SPI2 transmit lives in `main.cpp` (`ws2812Send()`).
 - **`lib/buzzer/buzzer.{h,cpp}`** — `buzzerPattern()` (situation → §3 sound pattern) and `buzzerOnAt()`
   (periodic on/off envelope). Pure; `tone()` drive lives in `main.cpp` (`applyBuzzer()`).
+- **`lib/ack/ack.{h,cpp}`** — `updateAck()` acknowledge state machine (§6): mutes sound while keeping
+  LED+screen, re-arms on a higher-priority alert, auto-returns when clear. Pure; the PB5 read + edge
+  detect live in `main.cpp`.
 - `setup()` — serial @115200, status LED, OLED init (blocks in `blinkErrorLED()` on failure),
   servo attach + close, WS2812B (SPI2) init, 12-bit ADC.
 - `loop()` @200 ms — read sensors, then run the decision functions and dispatch outputs:
   `applyFlap()` (twin servos), `applyAlertLed()` (WS2812B primary + PC13 backup), `applyBuzzer()`
-  (piezo via `tone()`), `onSituationChange()` (edge-triggered voice — stubbed), and `updateDisplay()`.
-  `main.cpp` holds the evolving state (`flapOpen`, `lowPressAlarm`, `buzzerSounding`, `prevSituation`).
+  (piezo via `tone()`, muted when acknowledged), `onSituationChange()` (edge-triggered voice — stubbed),
+  and `updateDisplay()`. The PB5 touch button feeds `updateAck()` each loop. `main.cpp` holds the
+  evolving state (`flapOpen`, `lowPressAlarm`, `buzzerSounding`, `ackState`, `prevSituation`).
 - **Tests**: `test/test_*/` (Unity) run via `pio test -e native` against `lib/` — the `native` env
   excludes `src/` so no hardware/toolchain is needed.
 
@@ -68,7 +72,7 @@ Notes: `Servo` lib owns **TIM2**, `tone()` owns **TIM3** (shared timers — don'
 CAN uses the USB pins → remove the PA12 USB pull-up. WS2812B needs a level shifter (or ~4.3V supply).
 
 `main.cpp` includes `pins.h` and uses these macros directly — change a pin in `pins.h` only.
-Wired but not yet coded: MP3, button, CAN.
+Wired but not yet coded: MP3, CAN.
 
 ## Layout & workflow
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Library dependencies (auto-installed): Adafruit SSD1306 + Adafruit GFX (firmware
 ## Architecture
 
 - **`lib/`** — **pure, Arduino-free** logic: `decision/` (situation matrix, hysteresis, interpolation,
-  sensor conversions), `ws2812/` (WS2812B pixel → SPI byte encoding), and `buzzer/` (alert patterns +
-  envelope). State is passed in as parameters, so it builds and runs natively and is fully unit-testable.
+  sensor conversions), `ws2812/` (WS2812B pixel → SPI byte encoding), `buzzer/` (alert patterns +
+  envelope), and `ack/` (acknowledge state machine). State is passed in as parameters, so it builds and
+  runs natively and is fully unit-testable.
 - **`src/main.cpp`** — owns all hardware I/O (servos, OLED, ADC, LEDs, SPI, serial) and the evolving
   state, calling into `lib/` each 200 ms loop.
 
@@ -90,10 +91,11 @@ request and on pushes to `main`.
 
 **Implemented:** temperature + pressure reading, twin-servo thermal regulation with hysteresis, the
 full situation decision matrix with adaptive low-pressure floor, OLED status display, WS2812B RGB
-alert indicator (off/yellow/red) with onboard backup LED, buzzer alert patterns, native tests + CI.
+alert indicator (off/yellow/red) with onboard backup LED, buzzer alert patterns, ACK touch button
+(mutes sound, §6), native tests + CI.
 
-**Wired but not yet coded** (pins assigned, schematic complete): MP3 voice prompts, ACK touch button,
-CAN / engine-RPM input. See `DECISION_MATRIX.md` for the roadmap.
+**Wired but not yet coded** (pins assigned, schematic complete): MP3 voice prompts, CAN / engine-RPM
+input. See `DECISION_MATRIX.md` for the roadmap.
 
 ## Schematics
 

--- a/lib/ack/ack.cpp
+++ b/lib/ack/ack.cpp
@@ -1,0 +1,27 @@
+#include "ack.h"
+
+// Situations are declared in priority order, so a smaller enum value means a
+// higher priority (SIT_TEMP_SENSOR_ERR is highest, SIT_COLD lowest).
+
+AckState updateAck(AckState prev, Situation current, bool ackEdge) {
+    AckState s = prev;
+
+    // Condition cleared (no active alert) -> auto-return to not-acknowledged.
+    if (situationAlert(current) == ALERT_OFF) {
+        s.acked = false;
+        return s;
+    }
+
+    // A new alert of strictly higher priority re-arms sound despite a prior ack.
+    if (s.acked && current < s.ackedSituation) {
+        s.acked = false;
+    }
+
+    // Button press acknowledges the current alert (mutes sound/voice).
+    if (ackEdge) {
+        s.acked = true;
+        s.ackedSituation = current;
+    }
+
+    return s;
+}

--- a/lib/ack/ack.h
+++ b/lib/ack/ack.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "decision.h" // Situation, situationAlert
+
+// Acknowledge state machine (DECISION_MATRIX §6). Pure / unit-testable; the
+// button read + edge detection live in src/main.cpp.
+//
+// Acknowledging mutes the sound/voice channel but keeps the LED + screen while
+// the condition persists. A new higher-priority alert re-arms sound despite a
+// prior ack. When no alert is active the state auto-returns to not-acknowledged.
+
+struct AckState {
+    bool acked;                 // is the current alert acknowledged (sound muted)?
+    Situation ackedSituation;   // the situation that was acknowledged
+};
+
+// ackEdge = rising edge of the touch button this tick. Returns the next state.
+AckState updateAck(AckState prev, Situation current, bool ackEdge);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "decision.h"  // hardware-independent decision logic (unit-tested)
 #include "ws2812.h"    // WS2812B pixel encoding (unit-tested)
 #include "buzzer.h"    // buzzer alert patterns (unit-tested)
+#include "ack.h"       // acknowledge state machine (unit-tested)
 
 // ========== CONFIGURATION ==========
 
@@ -37,6 +38,8 @@ bool flapOpen = false;      // current flap state (hysteresis), starts closed
 bool lowPressAlarm = false; // adaptive low-pressure alarm state (§4)
 bool buzzerSounding = false; // current buzzer tone on/off (avoids retriggering tone())
 int prevSituation = -1;     // last dispatched situation (edge-triggered sound/voice)
+AckState ackState = {false, SIT_COLD}; // acknowledge state (§6)
+bool prevAckButton = false; // previous touch-button level (for rising-edge detect)
 
 // ----- WS2812B RGB LED (primary indicator) -----
 // Driven over SPI2 MOSI (PIN_WS2812_DATA); SCLK/MISO are SPI2's other pins,
@@ -74,6 +77,7 @@ void setup() {
     // ----- Built in initialization -----
     pinMode(PIN_STATUS_LED, OUTPUT);
     digitalWrite(PIN_STATUS_LED, HIGH); // High is off for the built-in LED
+    pinMode(PIN_ACK_BUTTON, INPUT);     // touch module drives the line (no pull)
 
     // ----- OLED Screen initialization -----
     OLED_I2C.begin(); // I2C at 400kHz by default (smoother display)
@@ -134,8 +138,9 @@ void applyAlertLed(AlertLevel level) {
 // ----- BUZZER (per-loop envelope) -----
 // Passive piezo on PIN_BUZZER via tone() (TIM3). The pure pattern/envelope logic
 // lives in lib/buzzer; here we only gate the tone on transitions.
-void applyBuzzer(Situation sit) {
-    bool on = buzzerOnAt(buzzerPattern(sit), millis());
+void applyBuzzer(Situation sit, bool muted) {
+    BuzzerPattern pattern = muted ? BUZZ_SILENT : buzzerPattern(sit);
+    bool on = buzzerOnAt(pattern, millis());
     if (on && !buzzerSounding)      { tone(PIN_BUZZER, BUZZER_FREQ_HZ); buzzerSounding = true; }
     else if (!on && buzzerSounding) { noTone(PIN_BUZZER); buzzerSounding = false; }
 }
@@ -222,11 +227,17 @@ void loop() {
                               : false; // readings unreliable -> drop the adaptive alarm
     Situation sit = evaluateSituation(resistance, vPressure, temperature, pressure, lowPressAlarm);
 
+    // ----- ACKNOWLEDGE (§6) -----
+    bool ackNow = digitalRead(PIN_ACK_BUTTON);
+    bool ackEdge = ackNow && !prevAckButton; // rising edge = touch
+    prevAckButton = ackNow;
+    ackState = updateAck(ackState, sit, ackEdge);
+
     // ----- OUTPUTS -----
     flapOpen = nextFlapState(sit, temperature, flapOpen);
     applyFlap(flapOpen);
-    applyAlertLed(situationAlert(sit));
-    applyBuzzer(sit);
+    applyAlertLed(situationAlert(sit)); // LED stays on even when acknowledged
+    applyBuzzer(sit, ackState.acked);   // ack mutes the buzzer
     if ((int)sit != prevSituation) { onSituationChange(sit); prevSituation = sit; }
     updateDisplay(sit, temperature, resistance, pressure, vPressure);
 

--- a/test/test_ack/test_ack.cpp
+++ b/test/test_ack/test_ack.cpp
@@ -1,0 +1,69 @@
+#include <unity.h>
+#include "ack.h"
+
+// Native unit tests for the acknowledge state machine (lib/ack).
+// Run: pio test -e native
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static AckState fresh() { return AckState{false, SIT_COLD}; }
+
+void test_no_alert_stays_not_acked(void) {
+    AckState s = updateAck(fresh(), SIT_NORMAL, false);
+    TEST_ASSERT_FALSE(s.acked);
+}
+
+void test_press_with_no_alert_does_nothing(void) {
+    // Can't acknowledge when there is nothing to acknowledge.
+    AckState s = updateAck(fresh(), SIT_NORMAL, true);
+    TEST_ASSERT_FALSE(s.acked);
+}
+
+void test_press_during_alert_acknowledges(void) {
+    AckState s = updateAck(fresh(), SIT_LOW_PRESSURE, true);
+    TEST_ASSERT_TRUE(s.acked);
+    TEST_ASSERT_EQUAL(SIT_LOW_PRESSURE, s.ackedSituation);
+}
+
+void test_acked_holds_while_condition_persists(void) {
+    AckState s = updateAck(AckState{true, SIT_LOW_PRESSURE}, SIT_LOW_PRESSURE, false);
+    TEST_ASSERT_TRUE(s.acked);
+}
+
+void test_auto_return_when_condition_clears(void) {
+    AckState s = updateAck(AckState{true, SIT_LOW_PRESSURE}, SIT_NORMAL, false);
+    TEST_ASSERT_FALSE(s.acked);
+}
+
+void test_higher_priority_rearms_sound(void) {
+    // Acked low-pressure (prio 3), then stop-engine (prio 2, higher) appears.
+    AckState s = updateAck(AckState{true, SIT_LOW_PRESSURE}, SIT_STOP_ENGINE, false);
+    TEST_ASSERT_FALSE(s.acked); // sound re-armed
+}
+
+void test_lower_priority_keeps_ack(void) {
+    // Acked stop-engine (prio 2), then it improves to overpressure (prio 4, lower).
+    AckState s = updateAck(AckState{true, SIT_STOP_ENGINE}, SIT_OVERPRESSURE, false);
+    TEST_ASSERT_TRUE(s.acked); // stays muted
+}
+
+void test_rearm_then_reack_same_tick(void) {
+    // Higher-priority alert appears AND the button is pressed in the same tick.
+    AckState s = updateAck(AckState{true, SIT_LOW_PRESSURE}, SIT_STOP_ENGINE, true);
+    TEST_ASSERT_TRUE(s.acked);
+    TEST_ASSERT_EQUAL(SIT_STOP_ENGINE, s.ackedSituation);
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_no_alert_stays_not_acked);
+    RUN_TEST(test_press_with_no_alert_does_nothing);
+    RUN_TEST(test_press_during_alert_acknowledges);
+    RUN_TEST(test_acked_holds_while_condition_persists);
+    RUN_TEST(test_auto_return_when_condition_clears);
+    RUN_TEST(test_higher_priority_rearms_sound);
+    RUN_TEST(test_lower_priority_keeps_ack);
+    RUN_TEST(test_rearm_then_reack_same_tick);
+    return UNITY_END();
+}


### PR DESCRIPTION
Implements the acknowledge behaviour from `DECISION_MATRIX.md` §6 on the PB5 touch button.

## What
- **`lib/ack/`** (new, pure, unit-tested) — `updateAck()` state machine:
  - pressing the button during an alert mutes sound/voice (keeps LED + screen),
  - a new **higher-priority** alert re-arms sound despite a prior ack,
  - state **auto-returns** to not-acknowledged when no alert is active,
  - pressing with no active alert does nothing.
- **`src/main.cpp`** — reads PB5 (plain `INPUT`, rising-edge detect) each loop, feeds `updateAck()`; `applyBuzzer()` is now muted when acknowledged, while `applyAlertLed()` stays lit.
- Docs: `CLAUDE.md` + `README.md` updated (ACK → implemented; `lib/ack` documented).

## Coverage
8 new native tests (ack-during-alert, hold, auto-return, higher-priority re-arm, lower-priority keeps mute, same-tick re-arm+re-ack, press-with-no-alert no-op). Total **51/51**.

## Verification
- `pio test -e native` → 51/51 passed
- `pio run -e bluepill_f103c8` → builds clean

## Notes
- Ack mutes the buzzer; MP3 voice is still stubbed and will read the same `ackState.acked` when added.
- The 200 ms loop samples the button, so a <200 ms tap could be missed — deliberate touches are fine; worth a bench check of the touch module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)