### PR TITLE
feat: MP3 voice prompts (USART1); move debug Serial to USART2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,13 +39,15 @@ and calls into it:
 - **`lib/ack/ack.{h,cpp}`** — `updateAck()` acknowledge state machine (§6): mutes sound while keeping
   LED+screen, re-arms on a higher-priority alert, auto-returns when clear. Pure; the PB5 read + edge
   detect live in `main.cpp`.
+- **`lib/voice/voice.{h,cpp}`** — `voiceTrack()` (situation → §7 MP3 file) and `dfplayerFrame()`
+  (DFPlayer Mini command frame + checksum). Pure; the USART1 write lives in `main.cpp`.
 - `setup()` — serial @115200, status LED, OLED init (blocks in `blinkErrorLED()` on failure),
   servo attach + close, WS2812B (SPI2) init, 12-bit ADC.
 - `loop()` @200 ms — read sensors, then run the decision functions and dispatch outputs:
   `applyFlap()` (twin servos), `applyAlertLed()` (WS2812B primary + PC13 backup), `applyBuzzer()`
-  (piezo via `tone()`, muted when acknowledged), `onSituationChange()` (edge-triggered voice — stubbed),
-  and `updateDisplay()`. The PB5 touch button feeds `updateAck()` each loop. `main.cpp` holds the
-  evolving state (`flapOpen`, `lowPressAlarm`, `buzzerSounding`, `ackState`, `prevSituation`).
+  (piezo via `tone()`, muted when acknowledged), `onSituationChange()` (edge-triggered MP3 voice via
+  USART1), and `updateDisplay()`. The PB5 touch button feeds `updateAck()` each loop. `main.cpp` holds
+  the evolving state (`flapOpen`, `lowPressAlarm`, `buzzerSounding`, `ackState`, `prevSituation`).
 - **Tests**: `test/test_*/` (Unity) run via `pio test -e native` against `lib/` — the `native` env
   excludes `src/` so no hardware/toolchain is needed.
 
@@ -67,12 +69,15 @@ and calls into it:
 | Flap servos ×2 (Servo→TIM2) | `PA6`/`PA7` | WS2812B RGB LED (SPI2 MOSI+DMA) | `PB15` |
 | MP3 (USART1) | `PA9`/`PA10` | Backup LED (onboard) | `PC13` |
 | CAN RX/TX | `PA11`/`PA12` | ACK touch button | `PB5` |
+| Debug Serial (USART2) | `PA2`/`PA3` | | |
 
 Notes: `Servo` lib owns **TIM2**, `tone()` owns **TIM3** (shared timers — don't reuse them for PWM).
-CAN uses the USB pins → remove the PA12 USB pull-up. WS2812B needs a level shifter (or ~4.3V supply).
+USART1 = MP3, USART2 = debug `Serial` (remapped via `build_flags` in `platformio.ini`, since the
+variant defaults `Serial` to USART1). CAN uses the USB pins → remove the PA12 USB pull-up. WS2812B
+needs a level shifter (or ~4.3V supply).
 
 `main.cpp` includes `pins.h` and uses these macros directly — change a pin in `pins.h` only.
-Wired but not yet coded: MP3, CAN.
+Wired but not yet coded: CAN.
 
 ## Layout & workflow
 

--- a/DECISION_MATRIX.md
+++ b/DECISION_MATRIX.md
@@ -102,9 +102,11 @@ Un `.mp3` numéroté par message. Langue : *à confirmer (français présumé)*.
 | Servos volet ×2 (Servo→TIM2) | PA6 / PA7 | LED RGB WS2812B | PB15 |
 | OLED I2C2 | PB10 / PB11 | LED secours intégrée | PC13 |
 | Module MP3 (USART1) | PA9 / PA10 | CAN (SN65HVD230) | PA11 / PA12 |
+| Debug Serial (USART2) | PA2 / PA3 | | |
 
 Alim : 12 V→5 V externe → servos + capteur pression + STM32 (broche 5 V) ; 3,3 V carte → OLED + CAN ;
 masses communes ; 470 µF par servo. CAN = broches USB → retirer le pull-up USB sur PA12.
+USART1 = MP3, USART2 = console de débogage (`Serial` remappé via `build_flags`).
 
 ## 9. Points ouverts
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Pin map (source of truth: [`src/pins.h`](src/pins.h)):
 | Flap servos ×2 (`Servo` → TIM2) | `PA6` / `PA7` | WS2812B RGB LED (SPI2 MOSI+DMA) | `PB15` |
 | MP3 module (USART1) | `PA9` / `PA10` | Onboard backup LED | `PC13` |
 | CAN RX / TX | `PA11` / `PA12` | ACK touch button | `PB5` |
+| Debug Serial (USART2) | `PA2` / `PA3` | | |
 
 Per-peripheral wiring decisions (supply rails, level handling, supporting parts) are documented in
 [`kicad/stm-auto/WIRING.md`](kicad/stm-auto/WIRING.md).
@@ -64,8 +65,8 @@ Library dependencies (auto-installed): Adafruit SSD1306 + Adafruit GFX (firmware
 
 - **`lib/`** — **pure, Arduino-free** logic: `decision/` (situation matrix, hysteresis, interpolation,
   sensor conversions), `ws2812/` (WS2812B pixel → SPI byte encoding), `buzzer/` (alert patterns +
-  envelope), and `ack/` (acknowledge state machine). State is passed in as parameters, so it builds and
-  runs natively and is fully unit-testable.
+  envelope), `ack/` (acknowledge state machine), and `voice/` (MP3 mapping + DFPlayer frames). State is
+  passed in as parameters, so it builds and runs natively and is fully unit-testable.
 - **`src/main.cpp`** — owns all hardware I/O (servos, OLED, ADC, LEDs, SPI, serial) and the evolving
   state, calling into `lib/` each 200 ms loop.
 
@@ -92,10 +93,10 @@ request and on pushes to `main`.
 **Implemented:** temperature + pressure reading, twin-servo thermal regulation with hysteresis, the
 full situation decision matrix with adaptive low-pressure floor, OLED status display, WS2812B RGB
 alert indicator (off/yellow/red) with onboard backup LED, buzzer alert patterns, ACK touch button
-(mutes sound, §6), native tests + CI.
+(mutes sound, §6), MP3 voice prompts (§7), native tests + CI.
 
-**Wired but not yet coded** (pins assigned, schematic complete): MP3 voice prompts, CAN / engine-RPM
-input. See `DECISION_MATRIX.md` for the roadmap.
+**Wired but not yet coded** (pins assigned, schematic complete): CAN / engine-RPM input. See
+`DECISION_MATRIX.md` for the roadmap.
 
 ## Schematics
 

--- a/kicad/stm-auto/WIRING.md
+++ b/kicad/stm-auto/WIRING.md
@@ -15,6 +15,7 @@ KiCad 7 (`stm-auto.kicad_sch`). Convention: rails/buses on **global labels** (`5
 | Buzzer (piezo) | PB6 | decided (below) |
 | ACK touch button | PB5 | decided (below) |
 | MP3 (DFPlayer Mini) | PA9/PA10 | decided (below) |
+| Debug serial header | PA2/PA3 | decided (below) |
 
 ---
 
@@ -93,5 +94,14 @@ generic `Connector_Generic:Conn_01x16` (or download symbol).
   (can damage the amp). #1 DFPlayer mistake.
 - Label these nets **`MP3_RX` / `MP3_TX`** to avoid clashing with the existing `RX`/`TX` labels; mind
   the TX↔RX cross-over.
+- **USART conflict:** the Blue Pill variant defaults `Serial` (debug) to USART1 — the MP3 pins. The
+  firmware reserves USART1 for MP3 and remaps debug `Serial` to **USART2 (PA2/PA3)** via `build_flags`
+  in `platformio.ini`. Add a 3-pin debug header (TX `PA2`, RX `PA3`, GND) for the serial console.
 
 Footprint: 2.54 mm header matching the physical module.
+
+## Debug serial — USART2 (PA2/PA3)
+
+3-pin header to a USB-TTL adapter for the 115200 console (`pio device monitor`). MCU TX `PA2` → adapter
+RX, MCU RX `PA3` ← adapter TX, common GND. `Connector_Generic:Conn_01x03`, footprint
+`Connector_PinHeader_2.54mm:PinHeader_1x03_P2.54mm_Vertical`.

--- a/lib/voice/voice.cpp
+++ b/lib/voice/voice.cpp
@@ -1,0 +1,27 @@
+#include "voice.h"
+
+int voiceTrack(Situation sit) {
+    switch (sit) {
+        case SIT_STOP_ENGINE:      return 4; // "surchauffe, coupez le moteur"
+        case SIT_LOW_PRESSURE:     return 3; // "pression d'huile basse"
+        case SIT_MILD_OVERHEAT:    return 2; // "temperature elevee"
+        case SIT_TEMP_SENSOR_ERR:
+        case SIT_PRESS_SENSOR_ERR: return 5; // "defaut capteur"
+        default:                   return 0; // overpressure / normal bands: no voice
+    }
+}
+
+void dfplayerFrame(uint8_t cmd, uint16_t param, uint8_t* out) {
+    out[0] = 0x7E;                      // start
+    out[1] = 0xFF;                      // version
+    out[2] = 0x06;                      // number of bytes (cmd..paramL)
+    out[3] = cmd;
+    out[4] = 0x00;                      // no command feedback
+    out[5] = (uint8_t)(param >> 8);     // param high
+    out[6] = (uint8_t)(param & 0xFF);   // param low
+    uint16_t sum = out[1] + out[2] + out[3] + out[4] + out[5] + out[6];
+    uint16_t chk = (uint16_t)(0u - sum); // two's-complement checksum
+    out[7] = (uint8_t)(chk >> 8);
+    out[8] = (uint8_t)(chk & 0xFF);
+    out[9] = 0xEF;                      // end
+}

--- a/lib/voice/voice.h
+++ b/lib/voice/voice.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <stdint.h>
+#include "decision.h" // Situation
+
+// MP3 voice prompts (DFPlayer Mini over USART1), DECISION_MATRIX §7.
+// Pure / unit-testable: the situation -> track mapping and the DFPlayer command
+// frame builder. The actual UART write lives in src/main.cpp.
+
+constexpr uint8_t DF_FRAME_LEN      = 10;
+constexpr uint8_t DF_CMD_PLAY_INDEX = 0x03; // play the Nth file on the card
+constexpr uint8_t DF_CMD_SET_VOLUME = 0x06; // volume 0..30
+constexpr uint8_t DF_CMD_STOP       = 0x16; // stop playback
+
+// Voice file index for a situation (§7); 0 = no voice.
+//   STOP_ENGINE->4  LOW_PRESSURE->3  MILD_OVERHEAT->2  sensor faults->5
+// (track 1 is the "system ready" jingle, played by the INIT phase — not here.)
+int voiceTrack(Situation sit);
+
+// Build a DFPlayer Mini command frame (10 bytes incl. checksum) into out[10].
+void dfplayerFrame(uint8_t cmd, uint16_t param, uint8_t* out);

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,12 @@ upload_protocol = stlink
 
 monitor_speed = 115200
 
+; Remap debug Serial to USART2 (PA2/PA3); USART1 (PA9/PA10) is reserved for the MP3 module.
+build_flags =
+    -D PIN_SERIAL_TX=PA2
+    -D PIN_SERIAL_RX=PA3
+    -D SERIAL_UART_INSTANCE=2
+
 lib_deps =
     adafruit/Adafruit SSD1306 @ ^2.5.7
     adafruit/Adafruit GFX Library @ ^1.11.5

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "ws2812.h"    // WS2812B pixel encoding (unit-tested)
 #include "buzzer.h"    // buzzer alert patterns (unit-tested)
 #include "ack.h"       // acknowledge state machine (unit-tested)
+#include "voice.h"     // MP3 voice mapping + DFPlayer frames (unit-tested)
 
 // ========== CONFIGURATION ==========
 
@@ -59,6 +60,21 @@ void ws2812ShowAlert(AlertLevel level) {
     ws2812Send(buf, sizeof(buf));
 }
 
+// ----- MP3 voice (DFPlayer Mini on USART1) -----
+// Debug Serial is on USART2 (see platformio.ini build_flags), so USART1 is free.
+const uint8_t MP3_VOLUME = 22; // 0..30
+
+HardwareSerial MP3Serial(PIN_MP3_RX, PIN_MP3_TX);
+
+void dfplayerSend(uint8_t cmd, uint16_t param) {
+    uint8_t frame[DF_FRAME_LEN];
+    dfplayerFrame(cmd, param, frame);
+    MP3Serial.write(frame, DF_FRAME_LEN);
+}
+
+void playVoice(int track) { if (track > 0) dfplayerSend(DF_CMD_PLAY_INDEX, (uint16_t)track); }
+void stopVoice()          { dfplayerSend(DF_CMD_STOP, 0); }
+
 
 // ========== SETUP ==========
 
@@ -95,6 +111,10 @@ void setup() {
     // ----- WS2812B initialization -----
     WS2812_SPI.begin();
     ws2812ShowAlert(ALERT_OFF); // start dark
+
+    // ----- MP3 initialization -----
+    MP3Serial.begin(9600);            // DFPlayer Mini default baud
+    dfplayerSend(DF_CMD_SET_VOLUME, MP3_VOLUME); // best-effort (module may still be booting)
 
     // ----- OTHER Settings -----
     analogReadResolution(12);
@@ -146,11 +166,11 @@ void applyBuzzer(Situation sit, bool muted) {
 }
 
 // ----- VOICE (edge-triggered) -----
-// MP3 voice (USART1) is wired but not yet driven.
-// TODO: trigger voice files (§7) on situation change; for now log only.
+// Play the situation's voice prompt (§7) once when it becomes active.
 void onSituationChange(Situation sit) {
     Serial.print("Situation -> ");
     Serial.println(situationName(sit));
+    playVoice(voiceTrack(sit));
 }
 
 // ----- DISPLAY -----
@@ -232,6 +252,7 @@ void loop() {
     bool ackEdge = ackNow && !prevAckButton; // rising edge = touch
     prevAckButton = ackNow;
     ackState = updateAck(ackState, sit, ackEdge);
+    if (ackEdge && ackState.acked) stopVoice(); // ack also silences an in-progress prompt
 
     // ----- OUTPUTS -----
     flapOpen = nextFlapState(sit, temperature, flapOpen);

--- a/src/pins.h
+++ b/src/pins.h
@@ -5,6 +5,8 @@
  *
  * Shared timers (library-owned — keep other PWM off them):
  *   TIM2 = Servo library   |   TIM3 = tone() (buzzer)   |   free: TIM1, TIM4.
+ * UARTs: USART1 = MP3 module   |   USART2 = debug Serial (remapped via build_flags
+ *   in platformio.ini, since the variant defaults Serial to USART1).
  * Power: external 12V->5V converter feeds the servos, pressure sensor and STM32
  *   (5V pin); onboard 3.3V feeds the OLED + CAN transceiver; all grounds common.
  * Levels: analog/ADC pins keep <=3.3V (3.6V abs max). 5V-tolerant: PA9/PA10, PB6/PB7.
@@ -26,9 +28,13 @@
 #define PIN_OLED_SDA      PB11  // I2C2 SDA
 
 // AUDIO
-#define PIN_MP3_TX        PA9   // USART1 TX -> module RX (3.3V module, own decoupled supply)
-#define PIN_MP3_RX        PA10  // USART1 RX <- module TX
+#define PIN_MP3_TX        PA9   // USART1 TX -> module RX (1k series); DFPlayer @ 5V
+#define PIN_MP3_RX        PA10  // USART1 RX <- module TX (5V TX into 5V-tolerant pin)
 #define PIN_BUZZER        PB6   // piezo via tone() (TIM3)
+
+// DEBUG — Serial log @115200 remapped here (build_flags), freeing USART1 for MP3
+#define PIN_DEBUG_TX      PA2   // USART2 TX
+#define PIN_DEBUG_RX      PA3   // USART2 RX
 
 // USER INPUT — capacitive touch module (VCC/GND/OUT); OUT idle LOW, HIGH on touch
 #define PIN_ACK_BUTTON    PB5   // acknowledge; plain INPUT (module drives it), rising edge
@@ -41,6 +47,6 @@
 #define PIN_CAN_RX        PA11
 #define PIN_CAN_TX        PA12
 
-// Free for future use: PA2/PA3 (USART2), PA4/PA5/PA8, PB0/PB1, PB7-PB9, PB12-PB14.
+// Free for future use: PA4/PA5/PA8, PB0/PB1, PB7-PB9, PB12-PB14.
 
 #endif // PINS_H

--- a/test/test_voice/test_voice.cpp
+++ b/test/test_voice/test_voice.cpp
@@ -1,0 +1,64 @@
+#include <unity.h>
+#include "voice.h"
+
+// Native unit tests for the MP3 voice mapping + DFPlayer frame (lib/voice).
+// Run: pio test -e native
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ---------- situation -> track (§7) ----------
+
+void test_voice_track_mapping(void) {
+    TEST_ASSERT_EQUAL_INT(4, voiceTrack(SIT_STOP_ENGINE));
+    TEST_ASSERT_EQUAL_INT(3, voiceTrack(SIT_LOW_PRESSURE));
+    TEST_ASSERT_EQUAL_INT(2, voiceTrack(SIT_MILD_OVERHEAT));
+    TEST_ASSERT_EQUAL_INT(5, voiceTrack(SIT_TEMP_SENSOR_ERR));
+    TEST_ASSERT_EQUAL_INT(5, voiceTrack(SIT_PRESS_SENSOR_ERR));
+}
+
+void test_voice_no_track_for_silent_situations(void) {
+    TEST_ASSERT_EQUAL_INT(0, voiceTrack(SIT_OVERPRESSURE)); // buzzer only, no voice
+    TEST_ASSERT_EQUAL_INT(0, voiceTrack(SIT_REGULATION));
+    TEST_ASSERT_EQUAL_INT(0, voiceTrack(SIT_NORMAL));
+    TEST_ASSERT_EQUAL_INT(0, voiceTrack(SIT_COLD));
+}
+
+// ---------- DFPlayer frame builder ----------
+
+void test_frame_play_track_1(void) {
+    // 7E FF 06 03 00 00 01 FE F7 EF
+    uint8_t expected[DF_FRAME_LEN] = {0x7E, 0xFF, 0x06, 0x03, 0x00, 0x00, 0x01, 0xFE, 0xF7, 0xEF};
+    uint8_t out[DF_FRAME_LEN];
+    dfplayerFrame(DF_CMD_PLAY_INDEX, 1, out);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, out, DF_FRAME_LEN);
+}
+
+void test_frame_set_volume_30(void) {
+    // 7E FF 06 06 00 00 1E FE D7 EF
+    uint8_t expected[DF_FRAME_LEN] = {0x7E, 0xFF, 0x06, 0x06, 0x00, 0x00, 0x1E, 0xFE, 0xD7, 0xEF};
+    uint8_t out[DF_FRAME_LEN];
+    dfplayerFrame(DF_CMD_SET_VOLUME, 30, out);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, out, DF_FRAME_LEN);
+}
+
+void test_frame_markers_and_checksum(void) {
+    uint8_t out[DF_FRAME_LEN];
+    dfplayerFrame(DF_CMD_PLAY_INDEX, 5, out);
+    TEST_ASSERT_EQUAL_HEX8(0x7E, out[0]);          // start marker
+    TEST_ASSERT_EQUAL_HEX8(0xEF, out[DF_FRAME_LEN - 1]); // end marker
+    // checksum = -(sum of bytes 1..6), so payload sum + 16-bit checksum == 0 mod 0x10000
+    uint16_t sum = out[1] + out[2] + out[3] + out[4] + out[5] + out[6];
+    uint16_t chk = (uint16_t)((out[7] << 8) | out[8]);
+    TEST_ASSERT_EQUAL_HEX16(0, (uint16_t)(sum + chk));
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_voice_track_mapping);
+    RUN_TEST(test_voice_no_track_for_silent_situations);
+    RUN_TEST(test_frame_play_track_1);
+    RUN_TEST(test_frame_set_volume_30);
+    RUN_TEST(test_frame_markers_and_checksum);
+    return UNITY_END();
+}


### PR DESCRIPTION
Drives the DFPlayer Mini for voice prompts (`DECISION_MATRIX.md` §7), and resolves a USART1 conflict found along the way.

## What
- **`lib/voice/`** (new, pure, unit-tested):
  - `voiceTrack(Situation)` → §7 file (stop-engine→4, low-pressure→3, mild-overheat→2, sensor faults→5; 0 = none).
  - `dfplayerFrame(cmd, param, out)` → 10-byte DFPlayer command frame with two's-complement checksum.
- **`src/main.cpp`** — DFPlayer over **USART1** (`HardwareSerial`): plays the prompt on situation change, stops it on acknowledge; sets volume in `setup()`.

## USART1 conflict (resolved)
The `variant_PILL_F103Cx` default maps `Serial` (debug) to **USART1 — the MP3 pins**. Fixed by remapping debug `Serial` to **USART2 (PA2/PA3)** via `platformio.ini` `build_flags`; existing `Serial.print` code is unchanged. Board docs updated: `pins.h`, `DECISION_MATRIX.md` §8 pinout, and `WIRING.md` (adds a PA2/PA3 debug header).

## Coverage
6 new native tests (voice mapping + DFPlayer frame/checksum, incl. exact `7E FF 06 03 00 00 01 FE F7 EF`). Total **56/56**.

## Verification
- `pio test -e native` → 56/56 passed
- `pio run -e bluepill_f103c8` → builds clean (Flash 62.3%)

## Bench / wiring notes
- New wiring: PA2/PA3 debug header (KiCad + physical), DFPlayer per `WIRING.md` (1 kΩ on RX, SPK→speaker).
- DFPlayer boot timing: `setup()` volume-set is best-effort; proper SD/ready sequencing comes with the INIT phase. Files `0002`–`0005.mp3` must be on the card in index order.

Only **CAN / engine-RPM** remains uncoded after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)